### PR TITLE
fix: Restore previous status of GC and GC::Profiler after profiling

### DIFF
--- a/spec/components/gc_profiler_spec.rb
+++ b/spec/components/gc_profiler_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'rack-mini-profiler'
+require 'mini_profiler/gc_profiler'
+
+describe Rack::MiniProfiler::GCProfiler do
+  before :each do
+    @app = lambda do |env|
+      env
+    end
+    @env = {}
+    @profiler = Rack::MiniProfiler::GCProfiler.new
+  end
+
+  describe '#profile_gc_time' do
+    it 'doesn\'t enable the gc if it was disabled previously' do
+      GC.disable
+
+      expect {
+        @profiler.profile_gc_time(@app, @env)
+      }.to_not change { GC.disable }
+
+      # Let's re-enable the GC for the rest of the test suite
+      GC.enable
+    end
+
+    it 'keeps the GC enable if it was enabled previously' do
+      expect {
+        @profiler.profile_gc_time(@app, @env)
+      }.to_not change { GC.enable }
+    end
+
+    it 'doesn\'t leave the GC Profiler enabled if it was disabled previously' do
+      GC::Profiler.enable
+
+      expect {
+        @profiler.profile_gc_time(@app, @env)
+      }.to_not change { GC::Profiler.enabled? }
+
+      GC::Profiler.disable
+    end
+
+
+    it 'keeps the GC Profiler disabled if it was disabled previously' do
+      expect {
+        @profiler.profile_gc_time(@app, @env)
+      }.to_not change { GC::Profiler.enabled? }
+    end
+  end
+
+  describe '#profile_gc' do
+    it 'doesn\'t leave the GC enabled if it was disabled previously' do
+      GC.disable
+
+      expect {
+        @profiler.profile_gc(@app, @env)
+      }.to_not change { GC.disable }
+
+      # Let's re-enable the GC for the rest of the test suite
+      GC.enable
+    end
+
+    it 'keeps the GC enabled if it was enabled previously' do
+      expect {
+        @profiler.profile_gc(@app, @env)
+      }.to_not change { GC.enable }
+    end
+
+  end
+end


### PR DESCRIPTION
When using the GCProfiler, profiling a request could end up changing the previous state of the GC and the GC::Profiler, leading to odd problems.
This pull requests addresses this issue, restoring GC::Profiler and GC to their previous state at the end of the request profiling.
