### PR TITLE
feature: Enabled travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.0.0
+bundler_args: ""
+services:
+  - redis
+  - memcached

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rack-mini-profiler
 
-[![Code Climate](https://codeclimate.com/github/MiniProfiler/rack-mini-profiler.png)](https://codeclimate.com/github/MiniProfiler/rack-mini-profiler)
+[![Code Climate](https://codeclimate.com/github/MiniProfiler/rack-mini-profiler.png)](https://codeclimate.com/github/MiniProfiler/rack-mini-profiler) [![Build Status](https://travis-ci.org/MiniProfiler/rack-mini-profiler.png)](https://travis-ci.org/MiniProfiler/rack-mini-profiler)
 
 Middleware that displays speed badge for every html page. Designed to work both in production and in development.
 


### PR DESCRIPTION
I added support for travis-ci builds, as well as the build-status in the README.

To enable travis for this repo, you'll have to follow steps 1 and 2 here: http://about.travis-ci.org/docs/user/getting-started/#Step-one%3A-Sign-in.

I couldn't add a build for jruby, because of the native extensions in the fast_stack gem.
