### PR TITLE
Fix recursive locking when backend is unresponsive

### DIFF
--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -15,7 +15,7 @@ module Rack
     attr_accessor :auto_inject, :base_url_path, :pre_authorize_cb, :position,
         :backtrace_remove, :backtrace_includes, :backtrace_ignores, :skip_schema_queries,
         :storage, :user_provider, :storage_instance, :storage_options, :skip_paths, :authorization_mode,
-        :toggle_shortcut, :start_hidden, :backtrace_threshold_ms
+        :toggle_shortcut, :start_hidden, :backtrace_threshold_ms, :storage_failure, :logger
 
     # Deprecated options
     attr_accessor :use_existing_jquery
@@ -37,6 +37,11 @@ module Rack
           @toggle_shortcut = 'Alt+P'
           @start_hidden = false
           @backtrace_threshold_ms = 0
+          @storage_failure = Proc.new do |exception|
+            if @logger
+              @logger.warn("MiniProfiler storage failure: #{exception.message}")
+            end
+          end
           self
         }
       end

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -331,16 +331,22 @@ module Rack
       end
 
 
-      # no matter what it is, it should be unviewed, otherwise we will miss POST
-      @storage.set_unviewed(page_struct['User'], page_struct['Id'])
-      @storage.save(page_struct)
+      begin
+        # no matter what it is, it should be unviewed, otherwise we will miss POST
+        @storage.set_unviewed(page_struct['User'], page_struct['Id'])
+        @storage.save(page_struct)
 
-      # inject headers, script
-      if headers['Content-Type'] && status == 200
-        client_settings.write!(headers)
+        # inject headers, script
+        if headers['Content-Type'] && status == 200
+          client_settings.write!(headers)
 
-        result = inject_profiler(env,status,headers,body)
-        return result if result
+            result = inject_profiler(env,status,headers,body)
+          return result if result
+        end
+      rescue Exception => e
+        if @config.storage_failure != nil
+          @config.storage_failure.call(e)
+        end
       end
 
       client_settings.write!(headers)

--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -22,6 +22,10 @@ module Rack::MiniProfilerRails
       c.authorization_mode = :whitelist
     end
 
+    if Rails.logger
+      c.logger = Rails.logger
+    end
+
     # The file store is just so much less flaky
     tmp = Rails.root.to_s + "/tmp/miniprofiler"
     FileUtils.mkdir_p(tmp) unless File.exists?(tmp)

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -190,5 +190,13 @@ describe Rack::MiniProfiler do
     end
   end
 
+  describe 'error handling when storage_instance fails to save' do
+    it "should recover gracefully" do
+      Rack::MiniProfiler.config.pre_authorize_cb = lambda {|env| true }
+      Rack::MiniProfiler::MemoryStore.any_instance.stub(:save) { raise "This error" }
+      Rack::MiniProfiler.config.storage_failure.should_receive(:call)
+      get '/html'
+    end
+  end
 
 end


### PR DESCRIPTION
If the backend server (e.g. Memcache) becomes unavailable, miniprofiler should not cause the entire app to crash

Instead it should failover to default storage and report the error by calling storage_failover
