### PR TITLE
Update railtie to install after known dependencies

### DIFF
--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -15,7 +15,8 @@ module Rack
     attr_accessor :auto_inject, :base_url_path, :pre_authorize_cb, :position,
         :backtrace_remove, :backtrace_includes, :backtrace_ignores, :skip_schema_queries,
         :storage, :user_provider, :storage_instance, :storage_options, :skip_paths, :authorization_mode,
-        :toggle_shortcut, :start_hidden, :backtrace_threshold_ms, :storage_failure, :logger
+        :toggle_shortcut, :start_hidden, :backtrace_threshold_ms, :storage_failure, :logger,
+        :insert_after_middlewares
 
     # Deprecated options
     attr_accessor :use_existing_jquery
@@ -37,6 +38,7 @@ module Rack
           @toggle_shortcut = 'Alt+P'
           @start_hidden = false
           @backtrace_threshold_ms = 0
+          @insert_after_middlewares = %w{HerokuDeflater::SkipBinary Rack::Deflater}
           @storage_failure = Proc.new do |exception|
             if @logger
               @logger.warn("MiniProfiler storage failure: #{exception.message}")


### PR DESCRIPTION
We ran into an issue deploying to Heroku and found this open issue on the old repo:  https://github.com/SamSaffron/MiniProfiler/issues/131

I noticed you were open to taking a patch for this, so here it is.  I'd be happy to add tests for it, but couldn't really think of how, if you have any ideas let me know.
