### PR TITLE
Option to make profiling disabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Rack::MiniProfiler.config.position = 'right'
 # Have Mini Profiler start in hidden mode - display with short cut (defaulted to 'Alt+P')
 Rack::MiniProfiler.config.start_hidden = true
 # Have Rack::MiniProfiler start disabled - you can use query string option to re-enable later
-Rack::MiniProfiler.config.start_disabled = true
+Rack::MiniProfiler.config.enabled = false
 # Don't collect backtraces on SQL queries that take less than 5 ms to execute
 # (necessary on Rubies earlier than 2.0)
 Rack::MiniProfiler.config.backtrace_threshold_ms = 5

--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -16,7 +16,7 @@ module Rack
         :backtrace_remove, :backtrace_includes, :backtrace_ignores, :skip_schema_queries,
         :storage, :user_provider, :storage_instance, :storage_options, :skip_paths, :authorization_mode,
         :toggle_shortcut, :start_hidden, :backtrace_threshold_ms, :storage_failure, :logger,
-        :insert_after_middlewares, :start_disabled
+        :insert_after_middlewares, :enabled
 
     # Deprecated options
     attr_accessor :use_existing_jquery
@@ -44,7 +44,7 @@ module Rack
               @logger.warn("MiniProfiler storage failure: #{exception.message}")
             end
           end
-          @start_disabled = false
+          @enabled = true
           self
         }
       end

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -204,10 +204,10 @@ module Rack
 
       if query_string =~ /pp=enable/
         skip_it = false
-        config.start_disabled = false
+        config.enabled = true
       end
 
-      if skip_it || config.start_disabled
+      if skip_it || !config.enabled
         status,headers,body = @app.call(env)
         client_settings.disable_profiling = true
         client_settings.write!(headers)

--- a/spec/components/config_spec.rb
+++ b/spec/components/config_spec.rb
@@ -5,8 +5,8 @@ module Rack
   describe MiniProfiler::Config do
 
     describe '.default' do
-      it 'has "disabled" set to false' do
-        MiniProfiler::Config.default.start_disabled.should be_false
+      it 'has "enabled" set to true' do
+        MiniProfiler::Config.default.enabled.should be_true
       end
     end
 

--- a/spec/components/profiler_spec.rb
+++ b/spec/components/profiler_spec.rb
@@ -24,9 +24,9 @@ describe Rack::MiniProfiler do
         Rack::MiniProfiler.config.auto_inject.should == false
       end
 
-      it 'allows us to set default disabled' do
-        Rack::MiniProfiler.config.start_disabled = true
-        Rack::MiniProfiler.config.start_disabled.should == true
+      it 'allows us to start the profiler disabled' do
+        Rack::MiniProfiler.config.enabled = false
+        Rack::MiniProfiler.config.enabled.should == false
       end
 
       it 'can reset the settings' do

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -139,7 +139,7 @@ describe Rack::MiniProfiler do
     end
 
     it 'disables default functionality' do
-      Rack::MiniProfiler.config.start_disabled = true
+      Rack::MiniProfiler.config.enabled = false
       get '/html'
       last_response.headers.has_key?('X-MiniProfiler-Ids').should be_false
     end
@@ -224,7 +224,7 @@ describe Rack::MiniProfiler do
 
   describe 'when profiler is disabled by default' do
     before(:each) do
-      Rack::MiniProfiler.config.start_disabled = true
+      Rack::MiniProfiler.config.enabled = false
       get '/html'
       last_response.headers.has_key?('X-MiniProfiler-Ids').should be_false
     end


### PR DESCRIPTION
Add a configuration option to start profiler disabled. Check its value to decide if profiling should be skipped for each page. Profiling can be re-enabled by setting the query parameter pp=enable.

Fixes issue #11.
