### PR TITLE
don't enable if whitelist and not authorized

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -202,7 +202,7 @@ module Rack
         skip_it = true
       end
 
-      if query_string =~ /pp=enable/
+      if query_string =~ /pp=enable/ && (@config.authorization_mode != :whitelist || MiniProfiler.request_authorized?)
         skip_it = false
         config.enabled = true
       end

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -175,6 +175,19 @@ describe Rack::MiniProfiler do
         get '/html?pp=enable'
         last_response.body.should include('/mini-profiler-resources/includes.js')
       end
+
+      it "does not re-enable functionality if not whitelisted" do
+        Rack::MiniProfiler.config.authorization_mode = :whitelist
+        get '/html?pp=enable'
+        last_response.body.should_not include('/mini-profiler-resources/includes.js')
+      end
+
+      it "re-enabled functionality if whitelisted" do
+        Rack::MiniProfiler.config.authorization_mode = :whitelist
+        expect(Rack::MiniProfiler).to receive(:request_authorized?) { true }.twice
+        get '/html?pp=enable'
+        last_response.body.should include('/mini-profiler-resources/includes.js')
+      end
     end
   end
 


### PR DESCRIPTION
This prevents just the cookie alone being enough to trigger profiling,
even if the profiling results cannot be viewed

closes #30
