### PR TITLE
Remove BOMs

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -1,4 +1,4 @@
-﻿"use strict";
+"use strict";
 var MiniProfiler = (function () {
     var $;
 

--- a/lib/html/includes.tmpl
+++ b/lib/html/includes.tmpl
@@ -1,4 +1,4 @@
-﻿<script id="profilerTemplate" type="text/x-jquery-tmpl">
+<script id="profilerTemplate" type="text/x-jquery-tmpl">
 
   <div class="profiler-result">
 

--- a/lib/html/list.css
+++ b/lib/html/list.css
@@ -1,4 +1,4 @@
-﻿tbody tr:nth-child(odd)    { background-color:#eee; }
+tbody tr:nth-child(odd)    { background-color:#eee; }
 tbody tr:nth-child(even)    { background-color:#fff; }
 table { border: 0; border-spacing:0;}
 tr {border: 0;}

--- a/lib/html/list.js
+++ b/lib/html/list.js
@@ -1,4 +1,4 @@
-﻿var MiniProfiler = MiniProfiler || {};
+var MiniProfiler = MiniProfiler || {};
 MiniProfiler.list = {
     init:
         function (options) {

--- a/lib/html/list.tmpl
+++ b/lib/html/list.tmpl
@@ -1,4 +1,4 @@
-﻿<script id="tableTemplate" type="text/x-jquery-tmpl">
+<script id="tableTemplate" type="text/x-jquery-tmpl">
   <table>
     <thead>
       <tr>

--- a/lib/html/share.html
+++ b/lib/html/share.html
@@ -1,4 +1,4 @@
-﻿<html>
+<html>
     <head>
         <title>{name} ({duration} ms) - Profiling Results</title>
         <script type='text/javascript' src='{path}jquery.1.7.1.js?v={version}'></script>


### PR DESCRIPTION
I removed byte order marks (see http://en.wikipedia.org/wiki/Byte_order_mark).

The reason is that they end up in the markup of the web application running rack-mini-profiler. This caused an issue on my site where the footer (which is supposed to stick to the absolute bottom of the page) is followed by 10 pixels of empty space.

![alt text](http://i.imgur.com/GrtjMGz.jpg)
