### PR TITLE
Option to configure flamegraph sampling rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Rack::MiniProfiler.config.enabled = false
 # Don't collect backtraces on SQL queries that take less than 5 ms to execute
 # (necessary on Rubies earlier than 2.0)
 Rack::MiniProfiler.config.backtrace_threshold_ms = 5
+# Set the sampling rate for flamegraph, in ms - defaults to 0.5ms
+Rack::MiniProfiler.config.flamegraph_sample_rate = 1
 ```
 
 
@@ -182,6 +184,7 @@ end
 * toggle_shortcut (default Alt+P) - a jquery.hotkeys.js-style keyboard shortcut, used to toggle the mini_profiler's visibility. See http://code.google.com/p/js-hotkeys/ for more info.
 * start_hidden (default false) - Whether or not you want the mini_profiler to be visible when loading a page
 * backtrace_threshold_ms (default zero) - Minimum SQL query elapsed time before a backtrace is recorded. Backtrace recording can take a couple of milliseconds on rubies earlier than 2.0, impacting performance for very small queries.
+* flamegraph_sample_rate (default 0.5ms) - How often fast_stack should get stack trace info to generate flamegraphs
 
 ## Special query strings
 

--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -12,11 +12,10 @@ module Rack
       @attributes
     end
 
-    attr_accessor :auto_inject, :base_url_path, :pre_authorize_cb, :position,
-        :backtrace_remove, :backtrace_includes, :backtrace_ignores, :skip_schema_queries,
-        :storage, :user_provider, :storage_instance, :storage_options, :skip_paths, :authorization_mode,
-        :toggle_shortcut, :start_hidden, :backtrace_threshold_ms, :storage_failure, :logger,
-        :enabled
+    attr_accessor :authorization_mode, :auto_inject, :backtrace_ignores, :backtrace_includes, :backtrace_remove,
+      :backtrace_threshold_ms, :base_url_path, :enabled, :flamegraph_sample_rate, :logger, :position,
+      :pre_authorize_cb, :skip_paths, :skip_schema_queries, :start_hidden, :storage, :storage_failure,
+      :storage_instance, :storage_options, :toggle_shortcut, :user_provider
 
     # Deprecated options
     attr_accessor :use_existing_jquery
@@ -38,6 +37,7 @@ module Rack
           @toggle_shortcut = 'Alt+P'
           @start_hidden = false
           @backtrace_threshold_ms = 0
+          @flamegraph_sample_rate = 0.5
           @storage_failure = Proc.new do |exception|
             if @logger
               @logger.warn("MiniProfiler storage failure: #{exception.message}")

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -280,8 +280,14 @@ module Rack
             # do not sully our profile with mini profiler timings
             current.measure = false
             # first param is the path
-            # 0.5 means attempt to collect a sample each 0.5 secs
-            flamegraph = Flamegraph.generate(nil, fidelity: 0.5, embed_resources: query_string =~ /embed/) do
+            # 0.5 means attempt to collect a sample each 0.5 millisecs
+            match_data = query_string.match(/flamegraph_sample_rate=(?<rate>[\d\.]+)/)
+            if match_data && !match_data[:rate].to_f.zero?
+              sample_rate = match_data[:rate].to_f
+            else
+              sample_rate = config.flamegraph_sample_rate
+            end
+            flamegraph = Flamegraph.generate(nil, fidelity: sample_rate, embed_resources: query_string =~ /embed/) do
               status,headers,body = @app.call(env)
             end
           end
@@ -478,6 +484,7 @@ module Rack
   pp=profile-gc-time: perform built-in gc profiling on this request (ruby 1.9.3 only)
   pp=profile-gc-ruby-head: requires the memory_profiler gem, new location based report
   pp=flamegraph: works best on Ruby 2.0, a graph representing sampled activity (requires the flamegraph gem).
+  pp=flamegraph&flamegraph_sample_rate=1: creates a flamegraph with the specified sample rate (in ms). Overrides value set in config
   pp=flamegraph_embed: works best on Ruby 2.0, a graph representing sampled activity (requires the flamegraph gem), embedded resources for use on an intranet.
   pp=trace-exceptions: requires Ruby 2.0, will return all the spots where your application raises execptions
 "


### PR DESCRIPTION
Sometimes it's useful to be able to control how precise the flamegraph generate by rack-mini-profiler is.
This pull-request provides two ways to do that:
- Permanently, using the `flamegraph_sample_rate` configuration option
- For a single request, using the `flamegraph_sample_rate` param in the query string

I kept the same value as before by default, and updated the docs accordingly.
