### PR TITLE
Allow Rack::MiniProfiler.config.pre_authorize_cb to be set in the app's initializer.

### DIFF
--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -7,7 +7,7 @@ module Rack::MiniProfilerRails
     c = Rack::MiniProfiler.config
 
     # By default, only show the MiniProfiler in development mode, in production allow profiling if post_authorize_cb is set
-    c.pre_authorize_cb = lambda { |env|
+    c.pre_authorize_cb ||= lambda { |env|
       !Rails.env.test?
     }
 


### PR DESCRIPTION
[By default](https://github.com/MiniProfiler/rack-mini-profiler/blob/master/lib/mini_profiler_rails/railtie.rb#L11), the MiniProfiler is not active in the test environment. 

We would like to make sure in an integration test that the tool can only be seen by developers. Therefore, we have tried to override this behavior.

Overriding this behavior in rails-app initializer did not work:

``` ruby
# my_app/config/initializers/mini_profiler.rb
Rack::MiniProfiler.config.pre_authorize_cb = lambda do |env|
  return true
end
```

This tiny pull request changes this and allows `Rack::MiniProfiler.config.pre_authorize_cb` to be set in an initializer. The [default setting](https://github.com/MiniProfiler/rack-mini-profiler/blob/master/lib/mini_profiler_rails/railtie.rb#L11) is only applied, if `pre_authorize_cb` is not set in an initializer before.
