### PR TITLE
remove travis from todo as it is done

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The new home for rack-mini-profiler is https://github.com/MiniProfiler/rack-mini
 - Setting up a build that reuses https://github.com/MiniProfiler/ui
 - Migrating the internal data structures [per the spec](https://github.com/MiniProfiler/ui)
 - Cleaning up the [horrendous class structure that is using strings as keys and crazy non-objects](https://github.com/MiniProfiler/rack-mini-profiler/blob/master/lib/mini_profiler/sql_timer_struct.rb#L36-L44)
-- Add travis-ci testing at least MRI 1.9.3, JRuby and MRI 2.0
 
 If you feel like taking on any of this start an issue and update us on your progress.
 


### PR DESCRIPTION
I noticed there is no licence for the repo. @SamSaffron could you please let me know under what licence is the code? I would add that to the readme under this PR.
