### PR TITLE
Sequel reports DB query execution time in seconds, but our internal API expects milliseconds, so convert them.

### DIFF
--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -222,7 +222,8 @@ if SqlPatches.class_exists?("Sequel::Database") && !SqlPatches.patched?
     class Database
       alias_method :log_duration_original, :log_duration
       def log_duration(duration, message)
-        ::Rack::MiniProfiler.record_sql(message, duration)
+        # `duration` will be in seconds, but we need it in milliseconds for internal consistency.
+        ::Rack::MiniProfiler.record_sql(message, duration * 1000)
         log_duration_original(duration, message)
       end
     end


### PR DESCRIPTION
I don't know if this is something that changed recently in Sequel, but I don't think it has.  As far as I can tell, Sequel has reported duration in seconds for at least the past 3 years (see commit: https://github.com/jeremyevans/sequel/commit/276028af2ed3ca88807c4fe55cd393b8cd36e68a).  However, the Sequel adapter in rack-mini-profiler seems to think it's getting milliseconds.  I don't want to be so bold as to say this has been broken right along, since someone must be using it, but my execution times were all being reported as 0ms until I patched it like so.  Now I have execution times appear in rack-mini-profiler that seem to match the actual execution times.
