### PR TITLE
Allow the MemoryStore thread to shut down so it won't remain live in hot deploy scenarios.

### DIFF
--- a/lib/mini_profiler/storage/memory_store.rb
+++ b/lib/mini_profiler/storage/memory_store.rb
@@ -2,6 +2,10 @@ module Rack
   class MiniProfiler
     class MemoryStore < AbstractStore
 
+      # Sub-class thread so we have a named thread (useful for debugging in Thread.list).
+      class CacheCleanupThread < Thread
+      end
+
       EXPIRES_IN_SECONDS = 60 * 60 * 24
 
       def initialize(args = nil)
@@ -14,12 +18,29 @@ module Rack
 
         # TODO: fix it to use weak ref, trouble is may be broken in 1.9 so need to use the 'ref' gem
         me = self
-        Thread.new do
-          while true do
-            me.cleanup_cache
-            sleep(3600)
+        t = CacheCleanupThread.new do
+          interval = 10
+          cleanup_cache_cycle = 3600
+          cycle_count = 1
+
+          until Thread.current[:should_exit] do
+            # We don't want to hit the filesystem every 10s to clean up the cache so we need to do a bit of
+            # accounting to avoid sleeping that entire time.  We don't want to sleep for the entire period because
+            # it means the thread will stay live in hot deployment scenarios, keeping a potentially large memory
+            # graph from being garbage collected upon undeploy.
+            if cycle_count * interval >= cleanup_cache_cycle
+              cycle_count = 1
+              me.cleanup_cache
+            end
+
+            sleep(interval)
+            cycle_count += 1
           end
         end
+
+        at_exit { t[:should_exit] = true }
+
+        t
       end
 
       def save(page_struct)


### PR DESCRIPTION
Fixes #42: Memory leak on JRuby.
