### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ c.storage_options = {:path => tmp}
 c.storage = ::Rack::MiniProfiler::FileStore
 config.middleware.use(::Rack::MiniProfiler)
 ::Rack::MiniProfiler.profile_method(ActionController::Base, :process) {|action| "Executing action: #{action}"}
-::Rack::MiniProfiler.profile_method(ActionView::Template, :render) {|x,y| "Rendering: #{@virtual_path}"}
+::Rack::MiniProfiler.profile_method(ActionView::Template, :render) {|x,y| "Rendering: #{path_without_format_and_extension}"}
 
 # monkey patch away an activesupport and json_pure incompatability
 # http://pivotallabs.com/users/alex/blog/articles/1332-monkey-patch-of-the-day-activesupport-vs-json-pure-vs-ruby-1-8


### PR DESCRIPTION
For Rails 2.3.11 (and above?), I had better luck modifying the render block so that it prints the `path_without_format_and_extension` method instead of `@virtual_path`.

I figured out the method name by looking inside [this](https://github.com/rails/rails/blob/v2.3.18/actionpack/lib/action_view/renderable_partial.rb#L19). I think `@virtual_path` is only used in Rails 3?
