### PR TITLE
Use ActiveSupport.on_load hook to defer ActionController and ActionView initialization

### DIFF
--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -43,8 +43,12 @@ module Rack::MiniProfilerRails
     app.middleware.insert(0, Rack::MiniProfiler)
 
     # Attach to various Rails methods
-    ::Rack::MiniProfiler.profile_method(ActionController::Base, :process) {|action| "Executing action: #{action}"}
-    ::Rack::MiniProfiler.profile_method(ActionView::Template, :render) {|x,y| "Rendering: #{@virtual_path}"}
+    ActiveSupport.on_load(:action_controller) do
+      ::Rack::MiniProfiler.profile_method(ActionController::Base, :process) {|action| "Executing action: #{action}"}
+    end
+    ActiveSupport.on_load(:action_view) do
+      ::Rack::MiniProfiler.profile_method(ActionView::Template, :render) {|x,y| "Rendering: #{@virtual_path}"}
+    end
   end
 
   class Railtie < ::Rails::Railtie


### PR DESCRIPTION
Bundling current version of mini_profiler immediately loads ActionController and ActionView when the gem is required, and thus triggers their whole initializaion scripts, even in situations that ActionView is not actually needed (e.g. booting up the Rails console, executing a model test, running a Rake task, etc.).

Here's a fix to lazy-load AC::Base and AV::Base via ActiveSupport.on_load hook so that these classes are loaded when actually referenced from the application.
