### PR TITLE
Use SVG for status badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rack-mini-profiler
 
-[![Code Climate](https://codeclimate.com/github/MiniProfiler/rack-mini-profiler.png)](https://codeclimate.com/github/MiniProfiler/rack-mini-profiler) [![Build Status](https://travis-ci.org/MiniProfiler/rack-mini-profiler.png)](https://travis-ci.org/MiniProfiler/rack-mini-profiler)
+[![Code Climate](https://img.shields.io/codeclimate/github/MiniProfiler/rack-mini-profiler.svg)](https://codeclimate.com/github/MiniProfiler/rack-mini-profiler) [![Build Status](https://img.shields.io/travis/MiniProfiler/rack-mini-profiler/master.svg)](https://travis-ci.org/MiniProfiler/rack-mini-profiler)
 
 Middleware that displays speed badge for every html page. Designed to work both in production and in development.
 


### PR DESCRIPTION
http://shields.io/ provides many standardized badges for OSS. The PNG versions provided by Shields are similar to the images currently used, but the SVG versions added here are more legible on high pixel density displays.
