### PR TITLE
Fix "cant modify frozen object" on PG adapters

### DIFF
--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -145,7 +145,9 @@ if SqlPatches.class_exists? "PG::Result"
       elapsed_time = ((Time.now - start).to_f * 1000).round(1)
       mapped = args[0]
       mapped = @prepare_map[mapped] || args[0] if @prepare_map
-      result.instance_variable_set("@miniprofiler_sql_id", ::Rack::MiniProfiler.record_sql(mapped, elapsed_time))
+      unless result.nil?
+        result.instance_variable_set("@miniprofiler_sql_id", ::Rack::MiniProfiler.record_sql(mapped, elapsed_time))
+      end
 
       result
     end


### PR DESCRIPTION
I believe this is very similar to https://github.com/MiniProfiler/rack-mini-profiler/pull/49
it's trying to modify a nil object so we better check for nil before
setting the instance var

I've been enjoying working on Spree with rack mini profiler installed but for some reason I started getting those errors today, probably some internal spree query change. Got that running on rails 4.0.3
