### PR TITLE
if current is nil, just skip it

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -304,7 +304,7 @@ module Rack
         trace.disable if trace
       end
 
-      skip_it = current.discard
+      skip_it = current.nil? ? true : current.discard
 
       if (config.authorization_mode == :whitelist && !MiniProfiler.request_authorized?)
         # this is non-obvious, don't kill the profiling cookie on errors or short requests


### PR DESCRIPTION
fixes undefined method `discard' for nil:NilClass.

here's the complete error that I got:

```
NoMethodError at /en/front_office/parks/31:Landgoed-Hommelheide
undefined method `discard' for nil:NilClass
Ruby    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/rack-mini-profiler-0.9.1/lib/mini_profiler/profiler.rb: in call, line 307
Web     GET localhost/en/front_office/parks/31:Landgoed-Hommelheide
Jump to:

    GET
    POST
    Cookies
    ENV

Traceback (innermost first)

    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/rack-mini-profiler-0.9.1/lib/mini_profiler/profiler.rb: in call
        skip_it = !current.nil? ? current.discard : true...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/railties-4.0.3/lib/rails/engine.rb: in call
        app.call(env)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/railties-4.0.3/lib/rails/application.rb: in call
        super(env)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/railties-4.0.3/lib/rails/railtie/configurable.rb: in method_missing
        instance.send(*args, &block)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/rack-1.5.2/lib/rack/lint.rb: in _call
        status, headers, @body = @app.call(env)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/rack-1.5.2/lib/rack/lint.rb: in call
        dup._call(env)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/rack-1.5.2/lib/rack/showexceptions.rb: in call
        @app.call(env)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/rack-1.5.2/lib/rack/commonlogger.rb: in call
        status, header, body = @app.call(env)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/rack-1.5.2/lib/rack/chunked.rb: in call
        status, headers, body = @app.call(env)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/rack-1.5.2/lib/rack/content_length.rb: in call
        status, headers, body = @app.call(env)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/unicorn-4.8.0/lib/unicorn/http_server.rb: in process_client
        status, headers, body = @app.call(env = @request.read(client))...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/unicorn-4.8.0/lib/unicorn/http_server.rb: in worker_loop
        process_client(client)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/newrelic_rpm-3.7.3.199/lib/new_relic/agent/instrumentation/unicorn_instrumentation.rb: in call
        old_worker_loop.bind(self).call(worker)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/newrelic_rpm-3.7.3.199/lib/new_relic/agent/instrumentation/unicorn_instrumentation.rb: in block (4 levels) in <top (required)>
        old_worker_loop.bind(self).call(worker)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/unicorn-4.8.0/lib/unicorn/http_server.rb: in spawn_missing_workers
        worker_loop(worker)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/unicorn-4.8.0/lib/unicorn/http_server.rb: in start
        spawn_missing_workers...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/gems/unicorn-4.8.0/bin/unicorn: in <top (required)>
        Unicorn::HttpServer.new(app, options).start.join...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/bin/unicorn: in load
        load Gem.bin_path('unicorn', 'unicorn', version)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/bin/unicorn: in <main>
        load Gem.bin_path('unicorn', 'unicorn', version)...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/bin/ruby_executable_hooks: in eval
        eval File.read($0), binding, $0...
    /home/behrooz/.rvm/gems/ruby-2.0.0-p353@bookingexperts/bin/ruby_executable_hooks: in <main>
        eval File.read($0), binding, $0...

```

after getting the error, tried to remove `tmp/miniprofiler/` directory which didn't help. However, this change fixed it.
