### PR TITLE
Add no-store to Cache-Control setting?

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -375,7 +375,7 @@ module Rack
 
       headers.delete('ETag')
       headers.delete('Date')
-      headers['Cache-Control'] = 'must-revalidate, private, max-age=0'
+      headers['Cache-Control'] = 'no-store, must-revalidate, private, max-age=0'
 
       # inject header
       if headers.is_a? Hash


### PR DESCRIPTION
Hello!

Appreciate if you can help us with this issue we're encountering with rack-mini-profiler, [wiselinks](https://github.com/igor-alexandrov/wiselinks), and Chrome.
### Description

Given I am using Chromium 33
And my Rails app is using both rack mini profiler 0.9.1 and wiselinks 1.2.0
And the app has a wiselinks-enabled link in some page A that loads another page B via ajax
And the app has another link that is not wiselinks-enabled
When I go to page A
And I click on the page B link
Then page B will be loaded via ajax
When I click on a link that is not wiselinks-enabled
And I return to page B with the back button of the browser
Then I will see page B without any layout
### Demo

You can find a demo of the bug at https://github.com/lovewithfood/rack-mini-profiler-wiselinks-bug-demo.
### Cause

wiselinks [sets](https://github.com/igor-alexandrov/wiselinks/blob/e473ebd81addf613e175ba729be68ae7834b2c37/lib/wiselinks/rendering.rb#L14) Cache-Control to 'no-cache, no-store, max-age=0, must-revalidate.' However, rack-mini-profiler removes the no-store value when it [sets](https://github.com/MiniProfiler/rack-mini-profiler/blob/734c8a5d47b0a4ce3a1d07e5fe3c6aa64dee548e/lib/mini_profiler/profiler.rb#L378) Cache-Control to 'must-revalidate, private, max-age=0'. According to [this StackOverflow post](http://stackoverflow.com/questions/16173322/google-chrome-does-not-revalidate-etag-on-back-forth), this allows Chrome to reload the wiselinks partial response from the cache when using the back button.

Chrome is the only browser I know encountering this issue. I haven't encountered the issue in Firefox or IE9 to 11.
### Solution/Work-around

Added no-store to the Cache-Control setting of rack-mini-profiler. 

Will this cause any issues with the gem?
