### PR TITLE
rack-mini-profiler should use Rails URL helpers when running under rails

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -588,7 +588,11 @@ Append the following to your query string:
     # * you have disabled auto append behaviour throught :auto_inject => false flag
     # * you do not want script to be automatically appended for the current page. You can also call cancel_auto_inject
     def get_profile_script(env)
-      path     = "#{env['RACK_MINI_PROFILER_ORIGINAL_SCRIPT_NAME']}#{@config.base_url_path}"
+      path = if env["action_controller.instance"]
+        env["action_controller.instance"].url_for("#{@config.base_url_path}")
+      else
+        "#{env['RACK_MINI_PROFILER_ORIGINAL_SCRIPT_NAME']}#{@config.base_url_path}"
+      end
 
       settings = {
        :path            => path,

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -134,6 +134,20 @@ describe Rack::MiniProfiler do
 
   end
 
+  describe 'within a Rails application' do
+
+    before do
+      mock_controller = double
+      mock_controller.should_receive(:url_for).with('/mini-profiler-resources/').and_return('/test/mini-profiler-resources/')
+      get '/html', nil, 'action_controller.instance' => mock_controller
+    end
+
+    it 'has the JS in the body with the correct path' do
+      last_response.body.include?('/test/mini-profiler-resources/includes.js').should be_true
+    end
+
+  end
+
 
   describe 'with a SCRIPT_NAME' do
 


### PR DESCRIPTION
When running under Rails, rack-mini-profiler should use the Rails
`#url_for` helper in order to correctly construct the path to the
profiler javascript when in a Rails engine context where SCRIPT_NAME is
inappropriate.

Fixes #25