### PR TITLE
Idiot-proof Rack::MiniProfilerRails.initialize! from being called twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Or you want to execute some code before rack_mini_profiler required.
 ```ruby
 gem 'rack-mini-profiler', require: false
 ```
+Note the `require: false` part - if omitted, it will cause the Railtie for the mino-profiler to
+be loaded outright, and an attempt to re-initialize it manually will raise an exception.
 
 Then put initialize code in file like `config/initializers/rack_profiler.rb`
 

--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -4,6 +4,9 @@ module Rack::MiniProfilerRails
 
   # call direct if needed to do a defer init
   def self.initialize!(app)
+    
+    raise "MiniProfilerRails initialized twice. Set `require: false' for rack-mini-profiler in your Gemfile" if @already_initialized
+      
     c = Rack::MiniProfiler.config
 
     # By default, only show the MiniProfiler in development mode, in production allow profiling if post_authorize_cb is set
@@ -52,6 +55,8 @@ module Rack::MiniProfilerRails
     ActiveSupport.on_load(:action_view) do
       ::Rack::MiniProfiler.profile_method(ActionView::Template, :render) {|x,y| "Rendering: #{@virtual_path}"}
     end
+    
+    @already_initialized = true
   end
 
   class Railtie < ::Rails::Railtie


### PR DESCRIPTION
This fixes the actual problem mentioned in https://github.com/MiniProfiler/rack-mini-profiler/pull/68 or at least prevents it from happening in a meaningful way.
