### PR TITLE
Fix gemspec

### DIFF
--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -1,20 +1,20 @@
 Gem::Specification.new do |s|
-	s.name = "rack-mini-profiler"
-	s.version = "0.9.1"
-	s.summary = "Profiles loading speed for rack applications."
-	s.authors = ["Sam Saffron", "Robin Ward","Aleks Totic"]
-	s.description = "Profiling toolkit for Rack applications with Rails integration. Client Side profiling, DB profiling and Server profiling."
-	s.email = "sam.saffron@gmail.com"
-	s.homepage = "http://miniprofiler.com"
+  s.name = "rack-mini-profiler"
+  s.version = "0.9.1"
+  s.summary = "Profiles loading speed for rack applications."
+  s.authors = ["Sam Saffron", "Robin Ward","Aleks Totic"]
+  s.description = "Profiling toolkit for Rack applications with Rails integration. Client Side profiling, DB profiling and Server profiling."
+  s.email = "sam.saffron@gmail.com"
+  s.homepage = "http://miniprofiler.com"
   s.license = "MIT"
-	s.files = [
-		'rack-mini-profiler.gemspec',
-	].concat( Dir.glob('lib/**/*').reject {|f| File.directory?(f) || f =~ /~$/ } )
-	s.extra_rdoc_files = [
-		"README.md",
-		"CHANGELOG.md"
-	]
-	s.add_runtime_dependency 'rack', '>= 1.1.3'
+  s.files = [
+    'rack-mini-profiler.gemspec',
+  ].concat( Dir.glob('lib/**/*').reject {|f| File.directory?(f) || f =~ /~$/ } )
+  s.extra_rdoc_files = [
+    "README.md",
+    "CHANGELOG.md"
+  ]
+  s.add_runtime_dependency 'rack', '>= 1.1.3'
   if RUBY_VERSION < "1.9"
     s.add_runtime_dependency 'json', '>= 1.6'
   end


### PR DESCRIPTION
`s/CHANGELOG/CHANGELOG.md` to avoid this when installing the Gem:

```
rack-mini-profiler at .../rack-mini-profiler did not have a valid gemspec.
    This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
    The validation message from Rubygems was:
      ["CHANGELOG"] are not files
```

(also replaced all tabs with spaces)
