### PR TITLE
Make staging environment bahave like production

### DIFF
--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -24,7 +24,7 @@ module Rack::MiniProfilerRails
       c.skip_schema_queries = true
     end
 
-    if Rails.env.production?
+    unless Rails.env.development? || Rails.env.test?
       c.authorization_mode = :whitelist
     end
 
@@ -43,7 +43,7 @@ module Rack::MiniProfilerRails
     # Quiet the SQL stack traces
     c.backtrace_remove = Rails.root.to_s + "/"
     c.backtrace_includes =  [/^\/?(app|config|lib|test)/]
-    c.skip_schema_queries =  Rails.env != 'production'
+    c.skip_schema_queries = (Rails.env.development? || Rails.env.test?)
 
     # Install the Middleware
     app.middleware.insert(0, Rack::MiniProfiler)


### PR DESCRIPTION
I'd expect the Gem to behave the same way in both production and staging environments. So instead of checking if we're in the production env, we now check if we're _not_ in development nor test which makes it a bit more robust.
