### PR TITLE
Add ability to cleanup event listeners (Useful with Turbolinks and single page apps)

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -332,7 +332,7 @@ var MiniProfiler = (function () {
     };
 
     var bindDocumentEvents = function () {
-        $(document).bind('click keyup', function (e) {
+        $(document).bind('click.mini-profiler keyup.mini-profiler', function (e) {
 
             // this happens on every keystroke, and :visible is crazy expensive in IE <9
             // and in this case, the display:none check is sufficient.
@@ -365,9 +365,19 @@ var MiniProfiler = (function () {
                 popupHide(button, popup);
             }
         });
-        $(document).bind('keydown', options.toggleShortcut, function(e) {
+        $(document).bind('keydown.mini-profiler', options.toggleShortcut, function(e) {
             $('.profiler-results').toggle();
         });
+
+        if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
+            $(document).bind('page:change.mini-profiler', function() {
+               unbindDocumentEvents();
+            });
+        }
+    };
+
+    var unbindDocumentEvents = function() {
+        $(document).unbind('.mini-profiler');
     };
 
     var initFullView = function () {
@@ -456,11 +466,11 @@ var MiniProfiler = (function () {
         // fetch profile results for any ajax calls
         // note, this does not use $ cause we want to hook into the main jQuery
         if (jQuery && jQuery(document) && jQuery(document).ajaxComplete) {
-            jQuery(document).ajaxComplete(jQueryAjaxComplete);
+            jQuery(document).bind('ajaxComplete.mini-profiler', jQueryAjaxComplete);
         }
 
         if (jQuery && jQuery(document).ajaxStart)
-            jQuery(document).ajaxStart(function () { ajaxStartTime = new Date(); });
+            jQuery(document).bind('ajaxStart.mini-profiler', function () { ajaxStartTime = new Date(); });
 
         // fetch results after ASP Ajax calls
         if (typeof (Sys) != 'undefined' && typeof (Sys.WebForms) != 'undefined' && typeof (Sys.WebForms.PageRequestManager) != 'undefined') {
@@ -687,6 +697,10 @@ var MiniProfiler = (function () {
                     $(deferInit);
                 });
             }
+        },
+
+        cleanUp: function() {
+            unbindDocumentEvents();
         },
 
         getClientTimingByName: function (clientTiming, name) {


### PR DESCRIPTION
- Namespace event bindings
- Add function to unbind namespaced events
- If Turbolinks is defined, bind an event to automatically clean up events on page:change
