### PR TITLE
Add support for Redis connection pool storage

### DIFF
--- a/lib/mini_profiler/storage/redis_pool_store.rb
+++ b/lib/mini_profiler/storage/redis_pool_store.rb
@@ -1,0 +1,56 @@
+module Rack
+  class MiniProfiler
+    #
+    # You may pass in either standard Redis configuration or a ConnectionPool
+    # instance directly:
+    #
+    # Rack::MiniProfiler.config.storage_options = { :pool => Sidekiq.redis_pool }
+    # Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisPoolStore
+    #
+    class RedisPoolStore < AbstractStore
+      attr_reader :redis
+
+      EXPIRES_IN_SECONDS = 60 * 60 * 24
+
+      def initialize(args = nil)
+        require 'redis'
+        require 'connection_pool'
+        @args               = args || {}
+        @prefix             = @args.delete(:prefix)     || 'MPRedisStore'
+        @expires_in_seconds = @args.delete(:expires_in) || EXPIRES_IN_SECONDS
+        @redis              = @args.delete(:pool)       || ConnectionPool.new { Redis.new(@args) }
+      end
+
+      def save(page_struct)
+        redis.with {|c| c.setex "#{@prefix}#{page_struct[:id]}", @expires_in_seconds, Marshal::dump(page_struct) }
+      end
+
+      def load(id)
+        raw = redis.with {|c| c.get "#{@prefix}#{id}" }
+        Marshal::load(raw) if raw
+      end
+
+      def set_unviewed(user, id)
+        redis.with {|c| c.sadd "#{@prefix}-#{user}-v", id }
+      end
+
+      def set_viewed(user, id)
+        redis.with {|c| c.srem "#{@prefix}-#{user}-v", id }
+      end
+
+      def get_unviewed_ids(user)
+        redis.with {|c| c.smembers "#{@prefix}-#{user}-v" }
+      end
+
+      def diagnostics(user)
+        redis.with do |c|
+"Redis prefix: #{@prefix}
+Redis location: #{c.client.host}:#{c.client.port} db: #{c.client.db}
+unviewed_ids: #{c.smembers "#{@prefix}-#{user}-v"}
+"
+        end
+      end
+
+    end
+  end
+end

--- a/lib/rack-mini-profiler.rb
+++ b/lib/rack-mini-profiler.rb
@@ -15,6 +15,7 @@ require 'mini_profiler/storage/abstract_store'
 require 'mini_profiler/storage/memcache_store'
 require 'mini_profiler/storage/memory_store'
 require 'mini_profiler/storage/redis_store'
+require 'mini_profiler/storage/redis_pool_store'
 require 'mini_profiler/storage/file_store'
 
 require 'mini_profiler/config'

--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'ZenTest'
   s.add_development_dependency 'autotest'
   s.add_development_dependency 'redis'
+  s.add_development_dependency 'connection_pool'
   s.add_development_dependency 'therubyracer'
   s.add_development_dependency 'less'
   s.add_development_dependency 'flamegraph'

--- a/spec/components/storage/redis_pool_store_spec.rb
+++ b/spec/components/storage/redis_pool_store_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe Rack::MiniProfiler::RedisPoolStore do
+
+  context 'establishing a connection to something other than the default' do
+    before do
+      @store = Rack::MiniProfiler::RedisPoolStore.new(:db=>2)
+    end
+
+    describe "connection" do
+      it 'can still store the resulting value' do
+        page_struct = Rack::MiniProfiler::TimerStruct::Page.new({})
+        page_struct[:id] = "XYZ"
+        page_struct[:random] = "random"
+        @store.save(page_struct)
+      end
+
+      it 'uses the correct db' do
+        # redis is private, and possibly should remain so?
+        underlying_client = @store.send(:redis).with{|c| c.client.db }
+
+        underlying_client.should == 2
+      end
+    end
+  end
+
+  context 'page struct' do
+
+    before do
+      @store = Rack::MiniProfiler::RedisPoolStore.new(nil)
+    end
+
+    describe 'storage' do
+
+      it 'can store a PageStruct and retrieve it' do
+        page_struct = Rack::MiniProfiler::TimerStruct::Page.new({})
+        page_struct[:id] = "XYZ"
+        page_struct[:random] = "random"
+        @store.save(page_struct)
+        page_struct = @store.load("XYZ")
+        page_struct[:random].should == "random"
+        page_struct[:id].should == "XYZ"
+      end
+
+      it 'can list unviewed items for a user' do
+        @store.set_unviewed('a', 'XYZ')
+        @store.set_unviewed('a', 'ABC')
+        @store.get_unviewed_ids('a').should =~ ['XYZ', 'ABC']
+      end
+
+      it 'can set an item to viewed once it is unviewed' do
+        @store.set_unviewed('a', 'XYZ')
+        @store.set_unviewed('a', 'ABC')
+        @store.set_viewed('a', 'XYZ')
+        @store.get_unviewed_ids('a').should == ['ABC']
+      end
+
+    end
+
+  end
+
+
+  describe 'diagnostics' do
+    before do
+      @store = Rack::MiniProfiler::RedisPoolStore.new(:db=>2)
+    end
+    it "returns useful info" do
+      res = @store.diagnostics('a')
+      expected = "Redis prefix: MPRedisStore\nRedis location: 127.0.0.1:6379 db: 2\nunviewed_ids: []\n"
+      expect(res).to eq(expected)
+    end
+  end
+
+end


### PR DESCRIPTION
Current MiniProfiler assumes it should create the Redis connection directly.  Allow a connection pool for proper and efficient multithreaded usage.
