### PR TITLE
Save and use original SCRIPT_NAME before calling an @app. Fix #25 and #114 + test

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -100,7 +100,7 @@ module Rack
 
         # Otherwise give the HTML back
         html = MiniProfiler.share_template.dup
-        html.gsub!(/\{path\}/, "#{env['SCRIPT_NAME']}#{@config.base_url_path}")
+        html.gsub!(/\{path\}/, "#{env['RACK_MINI_PROFILER_ORIGINAL_SCRIPT_NAME']}#{@config.base_url_path}")
         html.gsub!(/\{version\}/, MiniProfiler::ASSET_VERSION)
         html.gsub!(/\{json\}/, result_json)
         html.gsub!(/\{includes\}/, get_profile_script(env))
@@ -156,6 +156,9 @@ module Rack
       status = headers = body = nil
       query_string = env['QUERY_STRING']
       path         = env['PATH_INFO']
+
+      # Someone (e.g. Rails engine) could change the SCRIPT_NAME so we save it
+      env['RACK_MINI_PROFILER_ORIGINAL_SCRIPT_NAME'] = env['SCRIPT_NAME']
 
       skip_it = (@config.pre_authorize_cb && !@config.pre_authorize_cb.call(env)) ||
                 (@config.skip_paths && @config.skip_paths.any?{ |p| path[0,p.length] == p}) ||
@@ -501,7 +504,7 @@ module Rack
     # * you have disabled auto append behaviour throught :auto_inject => false flag
     # * you do not want script to be automatically appended for the current page. You can also call cancel_auto_inject
     def get_profile_script(env)
-      path     = "#{env['SCRIPT_NAME']}#{@config.base_url_path}"
+      path     = "#{env['RACK_MINI_PROFILER_ORIGINAL_SCRIPT_NAME']}#{@config.base_url_path}"
 
       settings = {
        :path            => path,

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -54,6 +54,12 @@ describe Rack::MiniProfiler do
           [200, {'Content-Type' => 'text/html'}, '<h1>path1</h1>']
         }
       end
+      map '/rails_engine' do
+        run lambda { |env|
+          env['SCRIPT_NAME'] = '/rails_engine'  # Rails engines do that
+          [200, {'Content-Type' => 'text/html'}, '<html><h1>Hi</h1></html>']
+        }
+      end
     }.to_app
   end
 
@@ -140,6 +146,21 @@ describe Rack::MiniProfiler do
     end
 
   end
+
+
+  describe 'within a rails engine' do
+
+    before do
+      get '/rails_engine'
+    end
+
+    it 'include the correct JS in the body' do
+      last_response.body.include?('/rails_engine/mini-profiler-resources/includes.js').should_not be_true
+      last_response.body.include?('src="/mini-profiler-resources/includes.js').should be_true
+    end
+
+  end
+
 
   describe 'configuration' do
     it "should remove caching headers by default" do


### PR DESCRIPTION
The issue is that Rails engines break `env['SCRIPT_NAME']`. So we just need to store it somewhere before calling `@app.call`.

Fixed #25 and #114.

CC  @mschuerig @kamilpogo @smarterclayton