### PR TITLE
cache won't deserialize across version upgrades

### DIFF
--- a/lib/mini_profiler/storage/memcache_store.rb
+++ b/lib/mini_profiler/storage/memcache_store.rb
@@ -9,6 +9,7 @@ module Rack
         require 'dalli' unless defined? Dalli
         args ||= {}
         @prefix             = args[:prefix]     || "MPMemcacheStore"
+        @prefix             += "-#{Rack::MiniProfiler::VERSION}"
         @client             = args[:client]     || Dalli::Client.new
         @expires_in_seconds = args[:expires_in] || EXPIRES_IN_SECONDS
       end


### PR DESCRIPTION
I just upgraded from 0.9.2 to 0.9.3. It looks like I'm going to need to purge my cache to get rid of this bad data. If what is serialized is changed, you should update the cache prefix. It may be worth including the gem version in the prefix just in case.

```
NameError: uninitialized constant Rack::MiniProfiler::PageTimerStruct

Stacktrace (most recent call first):

  active_support/inflector/methods.rb:263:in `const_get'
    candidate = constant.const_get(name)
  active_support/inflector/methods.rb:263:in `block in constantize'
    candidate = constant.const_get(name)
  active_support/inflector/methods.rb:259:in `each'
    names.inject(Object) do |constant, name|
  active_support/inflector/methods.rb:259:in `inject'
    names.inject(Object) do |constant, name|
  active_support/inflector/methods.rb:259:in `constantize'
    names.inject(Object) do |constant, name|
  active_support/core_ext/string/inflections.rb:66:in `constantize'
    ActiveSupport::Inflector.constantize(self)
  active_support/core_ext/marshal.rb:10:in `rescue in load_with_autoloading'
    $1.constantize
  active_support/core_ext/marshal.rb:6:in `load_with_autoloading'
    load_without_autoloading(source)
  mini_profiler/storage/memcache_store.rb:22:in `load'
    Marshal::load(raw) if raw
  mini_profiler/profiler.rb:81:in `serve_results'
    page_struct = @storage.load(id)
  mini_profiler/profiler.rb:118:in `serve_html'
    return serve_results(env) if file_name.eql?('results')
  mini_profiler/profiler.rb:175:in `call'
    return serve_html(env) if path.start_with? @config.base_url_path
```