### PR TITLE
Update misleading comment in railtie.rb

### DIFF
--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -9,7 +9,12 @@ module Rack::MiniProfilerRails
       
     c = Rack::MiniProfiler.config
 
-    # By default, only show the MiniProfiler in development mode, in production allow profiling if post_authorize_cb is set
+    # By default, only show the MiniProfiler in development mode.
+    # To use the MiniProfiler in production, call Rack::MiniProfiler.authorize_request
+    # from a hook in your ApplicationController
+    #
+    # Example:
+    #   before_action { Rack::MiniProfiler.authorize_request if current_user.is_admin? }
     #
     # NOTE: this must be set here with = and not ||=
     #  The out of the box default is "true"


### PR DESCRIPTION
There is no #post_authorize_cb

The comment here should likely be amended (or removed entirely if the statement is no longer true).