### PR TITLE
Check for dependencies with defined? rather than NameError

### DIFF
--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -8,18 +8,6 @@ class SqlPatches
     @patched = val
   end
 
-  def self.class_exists?(name)
-    eval(name + ".class").to_s.eql?('Class')
-  rescue NameError
-    false
-  end
-
-  def self.module_exists?(name)
-    eval(name + ".class").to_s.eql?('Module')
-  rescue NameError
-    false
-  end
-
   def self.record_sql(statement, &block)
     start  = Time.now
     result = yield
@@ -37,10 +25,10 @@ class SqlPatches
   end
 end
 
-require 'patches/db/mysql2'         if SqlPatches.class_exists? "Mysql2::Client"
-require 'patches/db/pg'             if SqlPatches.class_exists? "PG::Result"
-require 'patches/db/moped'          if SqlPatches.class_exists?("Moped::Node")
-require 'patches/db/plucky'         if SqlPatches.class_exists?("Plucky::Query")
-require 'patches/db/rsolr'          if SqlPatches.class_exists?("RSolr::Connection") && RSolr::VERSION[0] != "0"
-require 'patches/db/sequel'         if !SqlPatches.patched? && SqlPatches.class_exists?("Sequel::Database")
-require 'patches/db/activerecord'   if !SqlPatches.patched? && SqlPatches.module_exists?("ActiveRecord")
+require 'patches/db/mysql2'         if defined?(Mysql2::Client)
+require 'patches/db/pg'             if defined?(PG::Result)
+require 'patches/db/moped'          if defined?(Moped::Node)
+require 'patches/db/plucky'         if defined?(Plucky::Query)
+require 'patches/db/rsolr'          if defined?(RSolr::Connection) && RSolr::VERSION[0] != "0"
+require 'patches/db/sequel'         if !SqlPatches.patched? && defined?(Sequel::Database)
+require 'patches/db/activerecord'   if !SqlPatches.patched? && defined?(ActiveRecord)


### PR DESCRIPTION
This is consistent with the checks for Net::HTTP and ::Rails and reduces memory allocated by ActiveSupport handling the exceptions.