### PR TITLE
Use String#start_with? to check skipped paths

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -161,7 +161,7 @@ module Rack
       env['RACK_MINI_PROFILER_ORIGINAL_SCRIPT_NAME'] = env['SCRIPT_NAME']
 
       skip_it = (@config.pre_authorize_cb && !@config.pre_authorize_cb.call(env)) ||
-                (@config.skip_paths && @config.skip_paths.any?{ |p| path[0,p.length] == p}) ||
+                (@config.skip_paths && @config.skip_paths.any?{ |p| path.start_with?(p) }) ||
                 query_string =~ /pp=skip/
 
       has_profiling_cookie = client_settings.has_cookie?


### PR DESCRIPTION
It’s more readable, faster and I’m quite sure it allocates less objects.

```ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  p1 = 'asdf'
  p2 = 'asdfsaskjdhflkajshdflkhjasdlfkhjasdskahslkjahfdlkajhslfkjhdalhdfsal'
  p3 = '8rh3iuhefiulrlhfjshdlhrluhfilrhilrushliufhrsdulirudhfliuhrslfidruhf'

  # Typical mode, runs the block as many times as it can
  x.report("start_with? => true") { p2.start_with? p1 }
  x.report("start_with? => false") { p3.start_with? p1 }
  x.report("start_with? => false (longer)") { p1.start_with? p3 }
  
  x.report("substring => true")  { p2[0..p1.length] == p1 }
  x.report("substring => false") { p3[0..p1.length] == p1 }
  x.report("substring => false (longer)") { p1[0..p3.length] == p3 }
end

# Calculating -------------------------------------
#  start_with? => true   137.723k i/100ms
# start_with? => false   136.665k i/100ms
# start_with? => false (longer)
#                        137.746k i/100ms
#    substring => true   105.539k i/100ms
#   substring => false   106.147k i/100ms
# substring => false (longer)
#                        104.700k i/100ms
# -------------------------------------------------
#  start_with? => true      6.879M (± 5.4%) i/s -     34.293M
# start_with? => false      6.926M (± 5.4%) i/s -     34.576M
# start_with? => false (longer)
#                           6.933M (± 6.9%) i/s -     34.574M
#    substring => true      2.825M (± 5.7%) i/s -     14.142M
#   substring => false      2.895M (± 4.5%) i/s -     14.542M
# substring => false (longer)
#                           2.759M (± 6.6%) i/s -     13.820M
```