### PR TITLE
Add mongo/mongoid5 support

### DIFF
--- a/lib/patches/db/mongo.rb
+++ b/lib/patches/db/mongo.rb
@@ -1,0 +1,12 @@
+# Mongo/Mongoid 5 patches
+class Mongo::Server::Connection
+  def dispatch_with_timing(*args, &blk)
+    return dispatch_without_timing(*args, &blk) unless SqlPatches.should_measure?
+
+    result, _record = SqlPatches.record_sql(args[0][0].payload.inspect) do
+      dispatch_without_timing(*args, &blk)
+    end
+    return result
+  end
+  alias_method_chain :dispatch, :timing
+end

--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -39,6 +39,7 @@ end
 
 require 'patches/db/mysql2'         if defined?(Mysql2::Client) && SqlPatches.class_exists?("Mysql2::Client")
 require 'patches/db/pg'             if defined?(PG::Result) && SqlPatches.class_exists?("PG::Result")
+require 'patches/db/mongo'          if defined?(Mongo) &&!SqlPatches.patched? && SqlPatches.module_exists?("Mongo")
 require 'patches/db/moped'          if defined?(Moped::Node) && SqlPatches.class_exists?("Moped::Node")
 require 'patches/db/plucky'         if defined?(Plucky::Query) && SqlPatches.class_exists?("Plucky::Query")
 require 'patches/db/rsolr'          if defined?(RSolr::Connection) && SqlPatches.class_exists?("RSolr::Connection") && RSolr::VERSION[0] != "0"


### PR DESCRIPTION
Mongoid 5 dropped moped and it's using default mongo driver.
This adds  support for it. 

Note:
I'm using ActiveSupport's method_chain because Mongoid already requires it, may change if you want.
