### PR TITLE
Support IPv6 addr on Windows Platform.

### DIFF
--- a/lib/mini_profiler/storage/file_store.rb
+++ b/lib/mini_profiler/storage/file_store.rb
@@ -26,8 +26,14 @@ module Rack
         end
 
         private
-        def path(key)
-          @path + "/" + @prefix  + "_" + key
+        if RUBY_PLATFORM =~ /mswin(?!ce)|mingw|cygwin|bccwin/
+          def path(key)
+            @path + "/" + @prefix  + "_" + key.gsub(/:/, '_')
+          end
+        else
+          def path(key)
+            @path + "/" + @prefix  + "_" + key
+          end
         end
       end
 


### PR DESCRIPTION
Replace ':' of key with '_' at FileStore#path method to avoid to include
unusable path charactor on Windows.
When using IPv6, localhost will be '::1' and it leads the "MiniProfiler
storage failure: Invalid argument @ rb_sysopen - #{path}" error.