### PR TITLE
Removed unused statement

### DIFF
--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -23,12 +23,7 @@ module Rack::MiniProfilerRails
     }
 
     c.skip_paths ||= []
-
     c.skip_paths << app.config.assets.prefix if serves_static_assets?(app)
-
-    if Rails.env.development?
-      c.skip_schema_queries = true
-    end
 
     unless Rails.env.development? || Rails.env.test?
       c.authorization_mode = :whitelist


### PR DESCRIPTION
`authorization_mode` is set later in same method.
