### PR TITLE
Updating README to include MRI 2.2 in flamegraph generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ To generate [flamegraphs](http://samsaffron.com/archive/2013/03/19/flame-graphs-
 * add the [**flamegraph**](https://github.com/SamSaffron/flamegraph) gem to your Gemfile
 * visit a page in your app with `?pp=flamegraph`
 
-Flamegraph generation is supported in MRI 2.0 and 2.1 only.
+Flamegraph generation is supported in MRI 2.0, 2.1, and 2.2 only.
 
 
 ## Access control in production


### PR DESCRIPTION
It seems to work fine with MRI 2.2 so I wanted to update the README file to include this version.