### PR TITLE
README header was not clear enough regarding authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To generate [flamegraphs](http://samsaffron.com/archive/2013/03/19/flame-graphs-
 Flamegraph generation is supported in MRI 2.0, 2.1, and 2.2 only.
 
 
-## Access control in production
+## Access control in non-development environments
 
 rack-mini-profiler is designed with production profiling in mind. To enable that just run `Rack::MiniProfiler.authorize_request` once you know a request is allowed to profile.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To generate [flamegraphs](http://samsaffron.com/archive/2013/03/19/flame-graphs-
 Flamegraph generation is supported in MRI 2.0, 2.1, and 2.2 only.
 
 
-## Access control in production
+## Access control in non-production environments
 
 rack-mini-profiler is designed with production profiling in mind. To enable that just run `Rack::MiniProfiler.authorize_request` once you know a request is allowed to profile.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ To generate [flamegraphs](http://samsaffron.com/archive/2013/03/19/flame-graphs-
 Flamegraph generation is supported in MRI 2.0, 2.1, and 2.2 only.
 
 
-## Access control in non-production environments
+## Access control in production
 
 rack-mini-profiler is designed with production profiling in mind. To enable that just run `Rack::MiniProfiler.authorize_request` once you know a request is allowed to profile.
 


### PR DESCRIPTION
It is not clear from the README that non-development environments need to authorize, not just production. If you read the comments in the source, it refers to 'non-development' as well. 