### PR TITLE
allow travis to use container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: ruby
+cache: bundler
+sudo: false
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1
-  - 2.2
-bundler_args: ""
+  - 2.1.7
+  - 2.2.3
 services:
   - redis
   - memcached


### PR DESCRIPTION
This is just some minor housekeeping to modernize the Travis config. It also explicitly sets ruby versions for 2.0 and 2.1 to latest version so tests don't run against 2.0.0 and 2.1.0.