### PR TITLE
Allow profile-memory to use params to configure MemoryProfiler report

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -203,8 +203,14 @@ module Rack
       end
 
       if query_string =~ /pp=profile-memory/
+        query_params = Rack::Utils.parse_nested_query(query_string)
+        options = {
+          :ignore_files => query_params['memory_profiler_ignore_files'],
+          :allow_files => query_params['memory_profiler_allow_files'],
+        }
+        options[:top]= Integer(query_params['memory_profiler_top']) if query_params.key?('memory_profiler_top')
         result = StringIO.new
-        report = MemoryProfiler.report do
+        report = MemoryProfiler.report(options) do
           _,_,body = @app.call(env)
           body.close if body.respond_to? :close
         end


### PR DESCRIPTION
This PR allows for 3 optional query params to be passed on to MemoryProfiler to configure the report.

The new params are:
* `memory_profiler_allow_files` - filename pattern to include
* `memory_profiler_ignore_files` - filename pattern to exclude
* `memory_profiler_top` - number of results per section

For example, to include ActiveRecord and Redis files it could be:
  `?pp=profile-memory&memory_profiler_allow_files=activerecord|redis&memory_profiler_top=5`

The parameters are optional of course and this will work (mostly) with MemoryProfiler 0.9.4. The ignore_files option only works with MemoryProfiler 0.9.5 since previously that required a Regexp param.

Let me know if you think there would be better query param names. The options aren't documented anywhere except in this PR. I didn't see a good place to document MemoryProfiler usage with MiniProfiler.
