### PR TITLE
Don't block the mongo patch when other DB patches are already loaded

### DIFF
--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -39,7 +39,7 @@ end
 
 require 'patches/db/mysql2'         if defined?(Mysql2::Client) && SqlPatches.class_exists?("Mysql2::Client")
 require 'patches/db/pg'             if defined?(PG::Result) && SqlPatches.class_exists?("PG::Result")
-require 'patches/db/mongo'          if defined?(Mongo) &&!SqlPatches.patched? && SqlPatches.module_exists?("Mongo")
+require 'patches/db/mongo'          if defined?(Mongo) && SqlPatches.module_exists?("Mongo")
 require 'patches/db/moped'          if defined?(Moped::Node) && SqlPatches.class_exists?("Moped::Node")
 require 'patches/db/plucky'         if defined?(Plucky::Query) && SqlPatches.class_exists?("Plucky::Query")
 require 'patches/db/rsolr'          if defined?(RSolr::Connection) && SqlPatches.class_exists?("RSolr::Connection") && RSolr::VERSION[0] != "0"


### PR DESCRIPTION
Found this when fixing #166. I think only ActiveRecord and Sequel should be blocked when other patches are already loaded because they would actually conflict. This check was probably added by accident. 