### PR TITLE
Add support for NoBrainer (rethinkdb) profiling

### DIFF
--- a/lib/patches/db/nobrainer.rb
+++ b/lib/patches/db/nobrainer.rb
@@ -1,0 +1,29 @@
+class Rack::MiniProfiler::NoBrainerProfiler
+
+  def on_query(env)
+    if SqlPatches.should_measure?
+      not_indexed = env[:criteria] && env[:criteria].where_present? &&
+                        !env[:criteria].where_indexed? &&
+                        !env[:criteria].model.try(:perf_warnings_disabled)
+
+      query = ""
+
+      # per-model/query database overrides
+      query << "[#{env[:options][:db]}] " if env[:options][:db]
+
+      # "read", "write" prefix
+      # query << "(#{NoBrainer::RQL.type_of(env[:query]).to_s}) "
+
+      query << "NOT USING INDEX: " if not_indexed
+      query << env[:query].inspect.gsub(/\n/, '').gsub(/ +/, ' ') + " "
+
+      if env[:exception]
+        query << "exception: #{env[:exception].class} #{env[:exception].message.split("\n").first} "
+      end
+
+      ::Rack::MiniProfiler.record_sql query.strip, env[:duration] * 1000.0
+    end
+  end
+
+  NoBrainer::Profiler.register self.new
+end

--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -52,3 +52,4 @@ require 'patches/db/plucky'           if defined?(Plucky::Query) && SqlPatches.c
 require 'patches/db/rsolr'            if defined?(RSolr::Connection) && SqlPatches.class_exists?("RSolr::Connection") && RSolr::VERSION[0] != "0"
 require 'patches/db/sequel'           if defined?(Sequel::Database) && !SqlPatches.patched? && SqlPatches.class_exists?("Sequel::Database")
 require 'patches/db/activerecord'     if defined?(ActiveRecord) &&!SqlPatches.patched? && SqlPatches.module_exists?("ActiveRecord")
+require 'patches/db/nobrainer'        if defined?(NoBrainer) && SqlPatches.module_exists?("NoBrainer")


### PR DESCRIPTION
This is a simple profiler integration that exposes the builtin NoBrainer
profiler to rack-mini-profiler. Should be pretty straightforward.

Highlighting is a bit off since mrp expects SQL in the frontend, but
nothing too shabby.

Also embedding some metadata in the profiler query string (things like
index usage) that the developer probably wants to see, but mrp hasn't
extra fields for.

--

Let me know what you think! :)

<img width="819" alt="screen shot 2015-11-16 at 16 03 36" src="https://cloud.githubusercontent.com/assets/11712/11185152/b162dc52-8c7b-11e5-8206-f4c3891a28f3.png">