### PR TITLE
Prevent ENV dumps via new config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The available configuration options are:
 * start_hidden (default false) - Whether or not you want the mini_profiler to be visible when loading a page
 * backtrace_threshold_ms (default zero) - Minimum SQL query elapsed time before a backtrace is recorded. Backtrace recording can take a couple of milliseconds on rubies earlier than 2.0, impacting performance for very small queries.
 * flamegraph_sample_rate (default 0.5ms) - How often fast_stack should get stack trace info to generate flamegraphs
+* disable_env_dump (default false) - When enabled, disables the `?pp=env` which can be useful when you are concerned about not sending ENV vars out over HTTP.
 
 ### Custom middleware ordering (required if using `Rack::Deflate` with Rails)
 

--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -13,7 +13,7 @@ module Rack
     end
 
     attr_accessor :authorization_mode, :auto_inject, :backtrace_ignores, :backtrace_includes, :backtrace_remove,
-      :backtrace_threshold_ms, :base_url_path, :disable_caching, :enabled, :flamegraph_sample_rate, :logger, :position,
+      :backtrace_threshold_ms, :base_url_path, :disable_caching, :disable_env_dump, :enabled, :flamegraph_sample_rate, :logger, :position,
       :pre_authorize_cb, :skip_paths, :skip_schema_queries, :start_hidden, :storage, :storage_failure,
       :storage_instance, :storage_options, :toggle_shortcut, :user_provider
 

--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -44,6 +44,7 @@ module Rack
             end
           end
           @enabled = true
+          @disable_env_dump = false
           self
         }
       end

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -305,7 +305,7 @@ module Rack
         return dump_exceptions exceptions
       end
 
-      if query_string =~ /pp=env/
+      if query_string =~ /pp=env/ && !config.disable_env_dump
         body.close if body.respond_to? :close
         return dump_env env
       end

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -271,6 +271,27 @@ describe Rack::MiniProfiler do
         last_response.body.should include('/mini-profiler-resources/includes.js')
       end
     end
+
+    describe 'disable_env_dump config option' do
+      context 'default (not configured' do
+        it 'allows env dump' do
+          get '/html?pp=env'
+
+          last_response.body.should include('QUERY_STRING')
+          last_response.body.should include('CONTENT_LENGTH')
+        end
+      end
+      context 'when enabled' do
+        it 'disables dumping the ENV over the web' do
+          Rack::MiniProfiler.config.disable_env_dump = true
+          get '/html?pp=env'
+
+          # Contains no ENV vars:
+          last_response.body.should_not include('QUERY_STRING')
+          last_response.body.should_not include('CONTENT_LENGTH')
+        end
+      end
+    end
   end
 
   describe 'POST followed by GET' do


### PR DESCRIPTION
I had a concern about dumping ENV vars into HTML in an app, and I wanted to disable it completely, so I added a config option here that just prevents `?pp=env` from functioning.