### PR TITLE
Fix jQuery templates not being fetched when jQuery dataType is defaulted to JSON

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -57,7 +57,7 @@ var MiniProfiler = (function () {
                     $('body').append(data);
                     success();
                 }
-            });
+            }, "text");
         }
     };
 


### PR DESCRIPTION
Explicitly specify a text response type for `jQuery.get` in case the application has set the default via 
`$.ajaxSetup({dataType: 'json'})` or similar.

See the last example on the docs page. https://api.jquery.com/jquery.get/