### PR TITLE
Support Rack 2.0 for Rails 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rack-mini-profiler (0.9.8)
-      rack (>= 1.1.3)
+      rack (>= 1.2.0)
 
 GEM
   remote: http://rubygems.org/

--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     "README.md",
     "CHANGELOG.md"
   ]
-  s.add_runtime_dependency 'rack', '>= 1.1.3'
+  s.add_runtime_dependency 'rack', '>= 1.2.0'
   if RUBY_VERSION < "1.9"
     s.add_runtime_dependency 'json', '>= 1.6'
   end


### PR DESCRIPTION
The `Rack::File` API has changed again with Rack 2.0, which is required for Rails 5. The profiler uses Rack::File to serve the CSS and JS files. Everything else seems to work fine with Rails 5.

This PR changes the way Rack::File is used to work with both Rack 1.2 and 2.0. This *does* break compatibility with Rack 1.1. My assumption was that anyone profiling an app would no longer be on a super old version of Rack.

Let me know if you'd rather keep Rack 1.1.x support and I can modify the code.