### PR TITLE
Allow backtrace_includes to work with an array of regexes

### DIFF
--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -17,11 +17,11 @@ module Rack
                     (
                       (
                         Rack::MiniProfiler.config.backtrace_includes.nil? or
-                        Rack::MiniProfiler.config.backtrace_includes.all?{|regex| ln =~ regex}
+                        Rack::MiniProfiler.config.backtrace_includes.any?{|regex| ln =~ regex}
                       ) and
                       (
                         Rack::MiniProfiler.config.backtrace_ignores.nil? or
-                        Rack::MiniProfiler.config.backtrace_ignores.all?{|regex| !(ln =~ regex)}
+                        Rack::MiniProfiler.config.backtrace_ignores.none?{|regex| ln =~ regex}
                       )
                     )
                 stack_trace << ln << "\n"

--- a/spec/components/timer_struct/sql_timer_struct_spec.rb
+++ b/spec/components/timer_struct/sql_timer_struct_spec.rb
@@ -46,8 +46,20 @@ describe Rack::MiniProfiler::TimerStruct::Sql do
       sql[:stack_trace_snippet].should match /rspec/
     end
 
-    it "ingores rspec if we specifically ignore it" do
+    it "includes rspec if we filter for it along with something else" do
+      Rack::MiniProfiler.config.backtrace_includes = [/rspec/, /something_else/]
+      sql = Rack::MiniProfiler::TimerStruct::Sql.new("SELECT * FROM users", 200, @page, nil)
+      sql[:stack_trace_snippet].should match /rspec/
+    end
+
+    it "ignores rspec if we specifically ignore it" do
       Rack::MiniProfiler.config.backtrace_ignores = [/\/rspec/]
+      sql = Rack::MiniProfiler::TimerStruct::Sql.new("SELECT * FROM users", 200, @page, nil)
+      sql[:stack_trace_snippet].should_not match /rspec/
+    end
+
+    it "ignores rspec if we specifically ignore it along with something else" do
+      Rack::MiniProfiler.config.backtrace_ignores = [/\/rspec/, /something_else/]
       sql = Rack::MiniProfiler::TimerStruct::Sql.new("SELECT * FROM users", 200, @page, nil)
       sql[:stack_trace_snippet].should_not match /rspec/
     end


### PR DESCRIPTION
With 2 Regexps configured in backtrace_ignores, no stack is ever shown. For example... 
```ruby
Rack::MiniProfiler.config.backtrace_includes = [/^\/?(app|config|lib|test)/] + [/my_special_gem/]
```
This PR changes `all?` to `any?` to match the backtrace_includes Regexps. 
The change to `none?` on the backtrace_ignores is just for readability.