### PR TITLE
allow class level methods to be profiled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 
+
+- [ADDED] Rack::MiniProfiler.profile_singleton_method (@kbrock)
+
 ## 0.9.8 - 2015-11-27 (Sam Saffron)
 
 - [FEATURE] disable_env_dump config setting (@mathias)

--- a/README.md
+++ b/README.md
@@ -167,6 +167,17 @@ Rack::MiniProfiler.config.user_provider = Proc.new{ |env| CurrentUser.get(env) }
 
 The string this function returns should be unique for each user on the system (for anonymous you may need to fall back to ip address)
 
+### Profiling specific methods
+
+You can increase the granularity of profiling by measuring the performance of specific methods. Add methods of interest to an initializer.
+
+```ruby
+Rails.application.config.to_prepare do
+  ::Rack::MiniProfiler.profile_singleton_method(User, :non_admins) { |a| "executing all_non_admins" }
+  ::Rack::MiniProfiler.profile_method(User, :favorite_post) { |a| "executing favorite_post" }
+end
+```
+
 ### Configuration Options
 
 You can set configuration options using the configuration accessor on `Rack::MiniProfiler`.

--- a/lib/mini_profiler/profiling_methods.rb
+++ b/lib/mini_profiler/profiling_methods.rb
@@ -109,6 +109,14 @@ module Rack
         klass.send :alias_method, method, with_profiling
       end
 
+      def profile_singleton_method(klass, method, type = :profile, &blk)
+        profile_method(singleton_class(klass), method, type, &blk)
+      end
+
+      def unprofile_singleton_method(klass, method)
+        unprofile_method(singleton_class(klass), method)
+      end
+
       # Add a custom timing. These are displayed similar to SQL/query time in
       # columns expanding to the right.
       #
@@ -133,6 +141,10 @@ module Rack
       end
 
       private
+
+      def singleton_class(klass)
+        class << klass; self; end
+      end
 
       def clean_method_name(method)
         method.to_s.gsub(/[\?\!]/, "")

--- a/spec/components/profiler_spec.rb
+++ b/spec/components/profiler_spec.rb
@@ -56,6 +56,10 @@ describe Rack::MiniProfiler do
         def foo(bar,baz)
           return [bar, baz, yield]
         end
+
+        def self.bar(baz,boo)
+          return [baz, boo, yield]
+        end
       end
     end
 
@@ -63,6 +67,12 @@ describe Rack::MiniProfiler do
       Rack::MiniProfiler.profile_method TestClass, :foo
       TestClass.new.foo("a","b"){"c"}.should == ["a","b","c"]
       Rack::MiniProfiler.unprofile_method TestClass, :foo
+    end
+
+    it 'should not destroy a singleton method' do
+      Rack::MiniProfiler.profile_singleton_method TestClass, :bar
+      TestClass.bar("a", "b"){"c"}.should == ["a","b","c"]
+      Rack::MiniProfiler.unprofile_singleton_method TestClass, :bar
     end
 
   end


### PR DESCRIPTION
I would like to profile a class level method.

Let me know if you would like a different approach.

---

If a method is to be profiled and it is not an instance method, then
define it on the singleton instance

This will only allow people to profile an instance method when both
a class level and instance level have the same name.