### PR TITLE
Allow hosts to be skipped from profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Option|Default|Description
 -------|---|--------
 pre_authorize_cb|Rails: dev only<br>Rack: always on|A lambda callback that returns true to make mini_profiler visible on a given request.
 position|`'left'`|Display mini_profiler on `'right'` or `'left'`.
+skip_hosts|`[]`|Hosts that skip profiling.
 skip_paths|`[]`|Paths that skip profiling.
 skip_schema_queries|Rails dev: `'true'`<br>Othwerwise: `'false'`|`'true'` to log schema queries.
 auto_inject|`true`|`true` to inject the miniprofiler script in the page.

--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -16,7 +16,7 @@ module Rack
       :backtrace_includes, :backtrace_remove, :backtrace_threshold_ms,
       :base_url_path, :disable_caching, :disable_env_dump, :enabled,
       :flamegraph_sample_rate, :logger, :position, :pre_authorize_cb,
-      :skip_paths, :skip_schema_queries, :start_hidden, :storage,
+      :skip_hosts, :skip_paths, :skip_schema_queries, :start_hidden, :storage,
       :storage_failure, :storage_instance, :storage_options, :toggle_shortcut,
       :user_provider
 

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -150,12 +150,14 @@ module Rack
       status = headers = body = nil
       query_string = env['QUERY_STRING']
       path         = env['PATH_INFO']
+      host         = (env["HTTP_HOST"] || env["SERVER_NAME"]).gsub(/:\d+\z/, '')
 
       # Someone (e.g. Rails engine) could change the SCRIPT_NAME so we save it
       env['RACK_MINI_PROFILER_ORIGINAL_SCRIPT_NAME'] = env['SCRIPT_NAME']
 
       skip_it = (@config.pre_authorize_cb && !@config.pre_authorize_cb.call(env)) ||
-                (@config.skip_paths && @config.skip_paths.any?{ |p| path.start_with?(p) }) ||
+                (@config.skip_hosts && @config.skip_hosts.any?{ |skip_host| host == skip_host }) ||
+                (@config.skip_paths && @config.skip_paths.any?{ |skip_path| path.start_with?(skip_path) }) ||
                 query_string =~ /pp=skip/
 
       has_profiling_cookie = client_settings.has_cookie?

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -212,6 +212,14 @@ describe Rack::MiniProfiler do
       last_response.headers.has_key?('X-MiniProfiler-Ids').should be_false
     end
 
+    it 'skips hosts listed' do
+      Rack::MiniProfiler.config.skip_hosts = ['skip-host.test']
+      get 'http://skip-host.test:8080/path1/a'
+      last_response.headers.has_key?('X-MiniProfiler-Ids').should be_false
+      get 'http://sample.org/path1/a'
+      last_response.headers.has_key?('X-MiniProfiler-Ids').should be_true
+    end
+
     it "skips paths listed" do
       Rack::MiniProfiler.config.skip_paths = ['/path/', '/path2/']
       get '/path2/a'


### PR DESCRIPTION
Some applications may include sub-apps with a different hosts for better isolation. If we allow paths to be skipped, I guess it also make sense to skip hosts.