### PR TITLE
Generate html method

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -41,10 +41,11 @@ module Rack
 
       def create_current(env={}, options={})
         # profiling the request
-        self.current               = Context.new
-        self.current.inject_js     = config.auto_inject && (!env['HTTP_X_REQUESTED_WITH'].eql? 'XMLHttpRequest')
-        self.current.page_struct   = TimerStruct::Page.new(env)
-        self.current.current_timer = current.page_struct[:root]
+        context               = Context.new
+        context.inject_js     = config.auto_inject && (!env['HTTP_X_REQUESTED_WITH'].eql? 'XMLHttpRequest')
+        context.page_struct   = TimerStruct::Page.new(env)
+        context.current_timer = context.page_struct[:root]
+        self.current          = context
       end
 
       def authorize_request


### PR DESCRIPTION
Want to generate the html from the command line.
Extracted the actual creation of the html in a separate method.

Sorry, got a little carried away modifying `generate_html` method.
Also trimmed down `insert`.
Want to call `create_context` and return the context. It seems odd to set the thread local variable so many times. I didn't find any places in the initialization chain that access `current` (or would need to in the guessable future)

Let me know if you want these as separate PRs (or if I should just get rid of any of this)

Thanks,
Keenan