### PR TITLE
Capture parameters for sql

### DIFF
--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -18,6 +18,7 @@ module Rack
       :flamegraph_sample_rate, :logger, :pre_authorize_cb, :skip_paths,
       :skip_schema_queries, :storage, :storage_failure, :storage_instance,
       :storage_options, :user_provider
+    attr_accessor :skip_sql_param_names, :max_sql_param_length
 
     # ui accessors
     attr_accessor :collapse_results, :max_traces_to_show, :position,
@@ -49,6 +50,8 @@ module Rack
           end
           @enabled = true
           @disable_env_dump = false
+          @max_sql_param_length = 0 # disable sql parameter collection by default
+          @skip_sql_param_names = /password/ # skips parameters with the name password by default
 
           # ui parameters
           @autorized          = true

--- a/lib/mini_profiler/profiling_methods.rb
+++ b/lib/mini_profiler/profiling_methods.rb
@@ -2,10 +2,10 @@ module Rack
   class MiniProfiler
     module ProfilingMethods
 
-      def record_sql(query, elapsed_ms)
+      def record_sql(query, elapsed_ms, params = nil)
         return unless current && current.current_timer
         c = current
-        c.current_timer.add_sql(query, elapsed_ms, c.page_struct, c.skip_backtrace, c.full_backtrace)
+        c.current_timer.add_sql(query, elapsed_ms, c.page_struct, params, c.skip_backtrace, c.full_backtrace)
       end
 
       def start_step(name)

--- a/lib/mini_profiler/timer_struct/request.rb
+++ b/lib/mini_profiler/timer_struct/request.rb
@@ -89,8 +89,8 @@ module Rack
           end
         end
 
-        def add_sql(query, elapsed_ms, page, skip_backtrace = false, full_backtrace = false)
-          TimerStruct::Sql.new(query, elapsed_ms, page, self , skip_backtrace, full_backtrace).tap do |timer|
+        def add_sql(query, elapsed_ms, page, params = nil, skip_backtrace = false, full_backtrace = false)
+          TimerStruct::Sql.new(query, elapsed_ms, page, self, params, skip_backtrace, full_backtrace).tap do |timer|
             self[:sql_timings].push(timer)
             timer[:parent_timing_id] = self[:id]
             self[:has_sql_timings]   = true

--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -4,7 +4,7 @@ module Rack
     # Timing system for a SQL query
     module TimerStruct
       class Sql < TimerStruct::Base
-        def initialize(query, duration_ms, page, parent, skip_backtrace = false, full_backtrace = false)
+        def initialize(query, duration_ms, page, parent, params = nil, skip_backtrace = false, full_backtrace = false)
 
           stack_trace = nil
           unless skip_backtrace || duration_ms < Rack::MiniProfiler.config.backtrace_threshold_ms
@@ -39,7 +39,7 @@ module Rack
             :start_milliseconds                => start_millis,
             :duration_milliseconds             => duration_ms,
             :first_fetch_duration_milliseconds => duration_ms,
-            :parameters                        => nil,
+            :parameters                        => params,
             :parent_timing_id                  => nil,
             :is_duplicate                      => false
           )

--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -17,10 +17,10 @@ class SqlPatches
     false
   end
 
-  def self.record_sql(statement, &block)
+  def self.record_sql(statement, parameters = nil, &block)
     start  = Time.now
     result = yield
-    record = ::Rack::MiniProfiler.record_sql( statement, elapsed_time(start) )
+    record = ::Rack::MiniProfiler.record_sql(statement, elapsed_time(start), parameters)
     return result, record
   end
 

--- a/spec/components/timer_struct/sql_timer_struct_spec.rb
+++ b/spec/components/timer_struct/sql_timer_struct_spec.rb
@@ -77,4 +77,29 @@ describe Rack::MiniProfiler::TimerStruct::Sql do
     end
   end
 
+  describe "#params" do
+    let(:sample_params) { [["name", "admin"], ["value", "string with more than 20"], ["limit", 1]] }
+    #def initialize(query, duration_ms, page, parent, params = nil, skip_backtrace = false, full_backtrace = false)
+    it "skips parameters by default" do
+      Rack::MiniProfiler.config.max_sql_param_length = 0
+      sql = sql_with_params(sample_params)
+      sql[:parameters].should be nil
+    end
+
+    it "stores parameters untouched" do
+      Rack::MiniProfiler.config.max_sql_param_length = nil
+      sql = sql_with_params(sample_params)
+      sql[:parameters].should eq sample_params
+    end
+
+    it "truncates string parameters" do
+      Rack::MiniProfiler.config.max_sql_param_length = 6
+      sql = sql_with_params(sample_params)
+      sql[:parameters].should eq [["name", "admin"], ["value", "string"], ["limit", 1]]
+    end
+
+    def sql_with_params(params)
+      Rack::MiniProfiler::TimerStruct::Sql.new("SELECT * FROM users", 200, @page, nil, params)
+    end
+  end
 end


### PR DESCRIPTION
Hi Sam/All,

Looks like the query parameters are not captured.
Not sure if this is by design, or an oversight.

Would you like a configuration parameter to turn this on or off.
Or some extra protections to limit passwords or large values?

Thanks
Keenan