### PR TITLE
fix get_profile_script when running under passenger configured with RailsBaseURI

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -571,10 +571,10 @@ Append the following to your query string:
     # * you have disabled auto append behaviour throught :auto_inject => false flag
     # * you do not want script to be automatically appended for the current page. You can also call cancel_auto_inject
     def get_profile_script(env)
-      path = if env["PASSENGER_BASE_URI"] then
+      path = if ENV["PASSENGER_BASE_URI"] then
         # added because the SCRIPT_NAME workaround below then
         # breaks running under a prefix as permitted by Passenger. 
-        "#{env['PASSENGER_BASE_URI']}#{@config.base_url_path}"
+        "#{ENV['PASSENGER_BASE_URI']}#{@config.base_url_path}"
       elsif env["action_controller.instance"]
         # Rails engines break SCRIPT_NAME; the following appears to discard SCRIPT_NAME
         # since url_for appears documented to return any String argument unmodified

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -571,7 +571,13 @@ Append the following to your query string:
     # * you have disabled auto append behaviour throught :auto_inject => false flag
     # * you do not want script to be automatically appended for the current page. You can also call cancel_auto_inject
     def get_profile_script(env)
-      path = if env["action_controller.instance"]
+      path = if env["PASSENGER_BASE_URI"] then
+        # added because the SCRIPT_NAME workaround below then
+        # breaks running under a prefix as permitted by Passenger. 
+        "#{env['PASSENGER_BASE_URI']}#{@config.base_url_path}"
+      elsif env["action_controller.instance"]
+        # Rails engines break SCRIPT_NAME; the following appears to discard SCRIPT_NAME
+        # since url_for appears documented to return any String argument unmodified
         env["action_controller.instance"].url_for("#{@config.base_url_path}")
       else
         "#{env['RACK_MINI_PROFILER_ORIGINAL_SCRIPT_NAME']}#{@config.base_url_path}"

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -60,6 +60,13 @@ describe Rack::MiniProfiler do
           [200, {'Content-Type' => 'text/html'}, '<html><h1>Hi</h1></html>']
         }
       end
+      map '/under_passenger' do
+        run lambda { |env|
+          env['SCRIPT_NAME'] = '/under_passenger'
+          env['PASSENGER_BASE_URI'] = '/under_passenger'
+          [200, {'Content-Type' => 'text/html'}, '<html><h1>and I ride and I ride</h1></html>']
+        }
+      end
     }.to_app
   end
 
@@ -171,6 +178,18 @@ describe Rack::MiniProfiler do
     it 'include the correct JS in the body' do
       last_response.body.include?('/rails_engine/mini-profiler-resources/includes.js').should_not be_true
       last_response.body.include?('src="/mini-profiler-resources/includes.js').should be_true
+    end
+
+  end
+
+  describe 'under passenger' do
+
+    before do
+      get '/under_passenger'
+    end
+
+    it 'include the correct JS in the body' do
+      last_response.body.include?('src="/under_passenger/mini-profiler-resources/includes.js').should be_true
     end
 
   end

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -63,7 +63,7 @@ describe Rack::MiniProfiler do
       map '/under_passenger' do
         run lambda { |env|
           env['SCRIPT_NAME'] = '/under_passenger'
-          env['PASSENGER_BASE_URI'] = '/under_passenger'
+          ENV['PASSENGER_BASE_URI'] = '/under_passenger'
           [200, {'Content-Type' => 'text/html'}, '<html><h1>and I ride and I ride</h1></html>']
         }
       end


### PR DESCRIPTION
This PR addresses a problem where running a Rails application under Passenger, which has been configured using its RailsBaseURI configuration option.  The mini-profiler would fail to load/display because the generated URL would lack the configured Base.  Other features would work, for example, if given the pp= option.  

The problem appeared to be caused by the fixes to #25 and #73 that handle rails engines by discarding SCRIPT_NAME when creating the URL to be injected.  This fix uses the environment variable PASSENGER_BASE_URI to act as SCRIPT_NAME had before the fix.  Rails engines are unlikely to alter the Passenger-specific variable as they altered SCRIPT_NAME, and any broader change might interact poorly with rails engines.  This patch may work if both passenger *and* rails engines are in use, but that is untested.