### PR TITLE
briefly document base_url_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ start_hidden|`false`|`false` to make mini_profiler visible on page load.
 backtrace_threshold_ms|`0`|Minimum SQL query elapsed time before a backtrace is recorded. Backtrace recording can take a couple of milliseconds on rubies earlier than 2.0, impacting performance for very small queries.
 flamegraph_sample_rate|`0.5ms`|How often to capture stack traces for flamegraphs.
 disable_env_dump|`false`|`true` disables `?pp=env`, which prevents sending ENV vars over HTTP.
+base_url_path|`'/mini-profiler-resources/'`|Path for assets; added as a prefix when naming assets and sought when responding to requests.
 
 ### Custom middleware ordering (required if using `Rack::Deflate` with Rails)
 


### PR DESCRIPTION
base_url_path has no documentation at the moment; this tries to explain it in the readme, though it could be more descriptive.  (i.e., feel free to reject or discuss.)