### PR TITLE
Enable Riak and Mongo with PG

### DIFF
--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -46,7 +46,7 @@ end
 require 'patches/db/mysql2'           if defined?(Mysql2::Client) && SqlPatches.class_exists?("Mysql2::Client")
 require 'patches/db/pg'               if defined?(PG::Result) && SqlPatches.class_exists?("PG::Result")
 require 'patches/db/oracle_enhanced'  if defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter) && SqlPatches.class_exists?("ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter") && SqlPatches.correct_version?('~> 1.5.0', ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
-require 'patches/db/mongo'            if defined?(Mongo) &&!SqlPatches.patched? && SqlPatches.module_exists?("Mongo")
+require 'patches/db/mongo'            if defined?(Mongo) && SqlPatches.module_exists?("Mongo")
 require 'patches/db/moped'            if defined?(Moped::Node) && SqlPatches.class_exists?("Moped::Node")
 require 'patches/db/plucky'           if defined?(Plucky::Query) && SqlPatches.class_exists?("Plucky::Query")
 require 'patches/db/rsolr'            if defined?(RSolr::Connection) && SqlPatches.class_exists?("RSolr::Connection") && RSolr::VERSION[0] != "0"

--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -53,5 +53,5 @@ require 'patches/db/rsolr'            if defined?(RSolr::Connection) && SqlPatch
 require 'patches/db/sequel'           if defined?(Sequel::Database) && !SqlPatches.patched? && SqlPatches.class_exists?("Sequel::Database")
 require 'patches/db/activerecord'     if defined?(ActiveRecord) &&!SqlPatches.patched? && SqlPatches.module_exists?("ActiveRecord")
 require 'patches/db/nobrainer'        if defined?(NoBrainer) && SqlPatches.module_exists?("NoBrainer")
-require 'patches/db/riak'             if defined?(Riak) && !SqlPatches.patched? && SqlPatches.module_exists?("Riak")
+require 'patches/db/riak'             if defined?(Riak) && SqlPatches.module_exists?("Riak")
 require 'patches/db/neo4j'            if defined?(Neo4j::Core) && SqlPatches.class_exists?("Neo4j::Core::Query")


### PR DESCRIPTION
This allows Riak and Mongo to work with a relational database.

The `SqlPatches.patched?` is only there to tell active_record/Sequel that the drivers are patched an there is no need to also patch active record.

FYI: you need to `gem "pg"` before `rack-mini-profiler` to use the native driver version.

fixes #167 (as it cherry picks the code)
fixes #194