### PR TITLE
Create tmp directory when actually using it

### DIFF
--- a/lib/mini_profiler/storage/file_store.rb
+++ b/lib/mini_profiler/storage/file_store.rb
@@ -44,6 +44,8 @@ module Rack
         @path = args[:path]
         @expires_in_seconds = args[:expires_in] || EXPIRES_IN_SECONDS
         raise ArgumentError.new :path unless @path
+        FileUtils.mkdir_p(@path) unless ::File.exists?(@path)
+
         @timer_struct_cache = FileCache.new(@path, "mp_timers")
         @timer_struct_lock  = Mutex.new
         @user_view_cache    = FileCache.new(@path, "mp_views")

--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -43,7 +43,6 @@ module Rack::MiniProfilerRails
     # The file store is just so much less flaky
     base_path = Rails.application.config.paths['tmp'].first rescue "#{Rails.root}/tmp"
     tmp       = base_path + '/miniprofiler'
-    FileUtils.mkdir_p(tmp) unless File.exists?(tmp)
 
     c.storage_options = {:path => tmp}
     c.storage = Rack::MiniProfiler::FileStore


### PR DESCRIPTION
This still creates a directory for filestore before being used, since
we don't want to do this lazy and possibly introduce a race condition.

But it now waits later in the configuration process, when profiler
creates the storage_instance

Fixes #152