### PR TITLE
throw away over 10 unviewed ids

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -552,8 +552,12 @@ Append the following to your query string:
     end
 
     def ids(env)
-      # cap at 10 ids, otherwise there is a chance you can blow the header
-      ([current.page_struct[:id]] + (@storage.get_unviewed_ids(user(env)) || [])[0..8]).uniq
+      all = ([current.page_struct[:id]] + (@storage.get_unviewed_ids(user(env)) || [])).uniq
+      if all.size > @config.max_traces_to_show
+        all = all[0...@config.max_traces_to_show]
+        @storage.set_all_unviewed(user(env), all)
+      end
+      all
     end
 
     def ids_json(env)

--- a/lib/mini_profiler/storage/abstract_store.rb
+++ b/lib/mini_profiler/storage/abstract_store.rb
@@ -18,6 +18,10 @@ module Rack
         raise NotImplementedError.new("set_viewed is not implemented")
       end
 
+      def set_all_unviewed(user, ids)
+        raise NotImplementedError.new("set_all_unviewed is not implemented")
+      end
+
       def get_unviewed_ids(user)
         raise NotImplementedError.new("get_unviewed_ids is not implemented")
       end

--- a/lib/mini_profiler/storage/file_store.rb
+++ b/lib/mini_profiler/storage/file_store.rb
@@ -114,6 +114,12 @@ module Rack
         }
       end
 
+      def set_all_unviewed(user, ids)
+        @user_view_lock.synchronize {
+          @user_view_cache[user] = ids.uniq
+        }
+      end
+
       def get_unviewed_ids(user)
         @user_view_lock.synchronize {
           @user_view_cache[user]

--- a/lib/mini_profiler/storage/memcache_store.rb
+++ b/lib/mini_profiler/storage/memcache_store.rb
@@ -43,6 +43,10 @@ module Rack
         end
       end
 
+      def set_all_unviewed(user, ids)
+        @client.set("#{@prefix}-#{user}-v", ids, @expires_in_seconds)
+      end
+
       def get_unviewed_ids(user)
         @client.get("#{@prefix}-#{user}-v") || []
       end

--- a/lib/mini_profiler/storage/memory_store.rb
+++ b/lib/mini_profiler/storage/memory_store.rb
@@ -98,6 +98,12 @@ module Rack
         }
       end
 
+      def set_all_unviewed(user, ids)
+        @user_view_lock.synchronize {
+          @user_view_cache[user] = ids
+        }
+      end
+
       def get_unviewed_ids(user)
         @user_view_lock.synchronize {
           @user_view_cache[user]

--- a/lib/mini_profiler/storage/redis_store.rb
+++ b/lib/mini_profiler/storage/redis_store.rb
@@ -33,6 +33,13 @@ module Rack
         redis.expire key, @expires_in_seconds
       end
 
+      def set_all_unviewed(user, ids)
+        key = "#{@prefix}-#{user}-v"
+        redis.del key
+        ids.each { |id| redis.sadd(key, id) }
+        redis.expire key, @expires_in_seconds
+      end
+
       def set_viewed(user, id)
         redis.srem "#{@prefix}-#{user}-v", id
       end

--- a/spec/components/profiler_spec.rb
+++ b/spec/components/profiler_spec.rb
@@ -130,9 +130,41 @@ describe Rack::MiniProfiler do
       it 'measures inner duration correctly' do
         @inner.duration_ms.to_i.should == 3 * 1000
       end
-
     end
-
   end
 
+  describe '#ids' do
+    let(:profiler) do
+      Rack::MiniProfiler.new(nil, :base_url_path => "/test-resource",
+                                  :storage       => Rack::MiniProfiler::MemoryStore,
+                                  :user_provider => Proc.new{|env| user_id },
+                            )
+    end
+
+    let(:current) { Rack::MiniProfiler.create_current }
+    let(:current_id) { current.page_struct[:id] }
+    let(:user_id) { "user1" }
+    let(:storage) { profiler.instance_variable_get(:@storage) } # not perfect but ...
+    before do
+      current
+    end
+
+    it "returns current id" do
+      expect(profiler.ids(user_id)).to eq([current_id])
+    end
+
+    it "uses existing ids" do
+      storage.set_unviewed(user_id, 1)
+      storage.set_unviewed(user_id, 2)
+
+      expect(profiler.ids(user_id)).to eq([current_id, 1, 2])
+    end
+
+    it "caps at config.max_traces_to_show ids" do
+      25.times { |i| storage.set_unviewed(user_id, i + 1) }
+
+      expect(profiler.ids(user_id)).to eq([current_id, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                                           11, 12, 13, 14, 15, 16, 17, 18, 19])
+    end
+  end
 end

--- a/spec/components/storage/file_store_spec.rb
+++ b/spec/components/storage/file_store_spec.rb
@@ -27,6 +27,14 @@ describe Rack::MiniProfiler::FileStore do
         @store.get_unviewed_ids('a').sort.to_a.should == ['XYZ', 'ABC'].sort.to_a
       end
 
+      it 'can set all unviewed items for a user' do
+        @store.set_unviewed('a', 'XYZ')
+        @store.set_unviewed('a', 'ABC')
+        @store.set_all_unviewed('a', %w(111 222))
+        @store.get_unviewed_ids('a').should == ['111', '222']
+        @store.set_all_unviewed('a', [])
+      end
+
       it 'can set an item to viewed once it is unviewed' do
         @store.set_unviewed('a', 'XYZ')
         @store.set_unviewed('a', 'ABC')

--- a/spec/components/storage/memcache_store_spec.rb
+++ b/spec/components/storage/memcache_store_spec.rb
@@ -27,6 +27,14 @@ describe Rack::MiniProfiler::MemcacheStore do
         @store.get_unviewed_ids('a').include?('ABC').should be_true
       end
 
+      it 'can set all unviewed items for a user' do
+        @store.set_unviewed('a', 'XYZ')
+        @store.set_unviewed('a', 'ABC')
+        @store.set_all_unviewed('a', %w(111 222))
+        @store.get_unviewed_ids('a').should == ['111', '222']
+        @store.set_all_unviewed('a', [])
+      end
+
       it 'can set an item to viewed once it is unviewed' do
         @store.set_unviewed('a', 'XYZ')
         @store.set_unviewed('a', 'ABC')

--- a/spec/components/storage/memory_store_spec.rb
+++ b/spec/components/storage/memory_store_spec.rb
@@ -24,6 +24,14 @@ describe Rack::MiniProfiler::MemoryStore do
         @store.get_unviewed_ids('a').should == ['XYZ', 'ABC']
       end
 
+      it 'can set all unviewed items for a user' do
+        @store.set_unviewed('a', 'XYZ')
+        @store.set_unviewed('a', 'ABC')
+        @store.set_all_unviewed('a', %w(111 222))
+        @store.get_unviewed_ids('a').should == ['111', '222']
+        @store.set_all_unviewed('a', [])
+      end
+
       it 'can set an item to viewed once it is unviewed' do
         @store.set_unviewed('a', 'XYZ')
         @store.set_unviewed('a', 'ABC')

--- a/spec/components/storage/redis_store_spec.rb
+++ b/spec/components/storage/redis_store_spec.rb
@@ -61,6 +61,14 @@ describe Rack::MiniProfiler::RedisStore do
         @store.get_unviewed_ids('a').should =~ ['XYZ', 'ABC']
       end
 
+      it 'can set all unviewed items for a user' do
+        @store.set_unviewed('a', 'XYZ')
+        @store.set_unviewed('a', 'ABC')
+        @store.set_all_unviewed('a', %w(111 222))
+        @store.get_unviewed_ids('a').should == ['111', '222']
+        @store.set_all_unviewed('a', [])
+      end
+
       it 'can set an item to viewed once it is unviewed' do
         @store.set_unviewed('a', 'XYZ')
         @store.set_unviewed('a', 'ABC')


### PR DESCRIPTION
fixes #127 

if there are more than 10 unviewed ids, it actually removes them from the storage.

Not thrilled about adding a method to Store.
@SamSaffron would you prefer just removing the `[0..8]`?

I didnt see how this would ever mark these as viewed.