### PR TITLE
Active support notifications

### DIFF
--- a/lib/mini_profiler/profiling_methods.rb
+++ b/lib/mini_profiler/profiling_methods.rb
@@ -8,6 +8,12 @@ module Rack
         c.current_timer.add_sql(query, elapsed_ms, c.page_struct, params, c.skip_backtrace, c.full_backtrace)
       end
 
+      def report_reader_duration(elapsed_ms, row_count = nil, class_name = nil)
+        return unless current && current.current_timer
+        c = current
+        c.current_timer.report_reader_duration(elapsed_ms, row_count, class_name)
+      end
+
       def start_step(name)
         return unless current
         parent_timer          = current.current_timer

--- a/lib/mini_profiler/timer_struct/request.rb
+++ b/lib/mini_profiler/timer_struct/request.rb
@@ -99,6 +99,13 @@ module Rack
           end
         end
 
+        # If possible, use instead: SqlTiming#report_reader_duration
+        def report_reader_duration(elapsed_ms, row_count = nil, class_name = nil)
+          last_time = self[:sql_timings] && self[:sql_timings].last
+          return unless last_time
+          last_time.report_reader_duration(elapsed_ms, row_count, class_name)
+        end
+
         def add_custom(type, elapsed_ms, page)
           TimerStruct::Custom.new(type, elapsed_ms, page, self).tap do |timer|
             timer[:parent_timing_id] = self[:id]

--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -45,12 +45,14 @@ module Rack
           )
         end
 
-        def report_reader_duration(elapsed_ms)
+        def report_reader_duration(elapsed_ms, row_count = nil, class_name = nil)
           return if @reported
           @reported = true
           self[:duration_milliseconds]                += elapsed_ms
           @parent[:sql_timings_duration_milliseconds] += elapsed_ms
           @page[:duration_milliseconds_in_sql]        += elapsed_ms
+          self[:row_count] = self[:row_count].to_i + row_count if row_count
+          self[:class_name] = class_name if class_name
         end
 
         def trim_binds(binds)

--- a/lib/patches/db/notifications.rb
+++ b/lib/patches/db/notifications.rb
@@ -6,6 +6,8 @@ module Rack
           elapsed_time = ((finish_time.to_f - start_time.to_f) * 1000).round(1)
           if name == "sql.active_record"
             Rack::MiniProfiler.record_sql(payload[:sql], elapsed_time, binds_to_params(payload[:binds]))
+          elsif name == 'instantiation.active_record'
+            Rack::MiniProfiler.report_reader_duration(elapsed_time, payload[:record_count], payload[:class_name])
           end
         end
       end
@@ -35,7 +37,7 @@ module Rack
 
     def self.subscribe_sql_notifications
       logger = ::Rack::MiniProfiler::ActiveRecordLogger.new
-      %w(sql.active_record).each do |event|
+      %w(sql.active_record instantiation.active_record).each do |event|
         ActiveSupport::Notifications.subscribe(event, logger)
       end
     end

--- a/lib/patches/db/notifications.rb
+++ b/lib/patches/db/notifications.rb
@@ -1,0 +1,45 @@
+module Rack
+  class MiniProfiler
+    class ActiveRecordLogger
+      def call(name, start_time, finish_time, id, payload)
+        if SqlPatches.should_measure? && !ignore_payload?(payload)
+          elapsed_time = ((finish_time.to_f - start_time.to_f) * 1000).round(1)
+          if name == "sql.active_record"
+            Rack::MiniProfiler.record_sql(payload[:sql], elapsed_time, binds_to_params(payload[:binds]))
+          end
+        end
+      end
+
+      def binds_to_params(binds)
+        return if binds.nil? || Rack::MiniProfiler.config.max_sql_param_length == 0
+        # map ActiveRecord::Relation::QueryAttribute to [name, value]
+        params = binds.map { |c| c.kind_of?(Array) ? [c.first, c.last] : [c.name, c.value] }
+        if (skip = Rack::MiniProfiler.config.skip_sql_param_names)
+          params.map { |(n,v)| n =~ skip ? [n, nil] : [n, v] }
+        else
+          params
+        end
+      end
+
+      # ORACLE and PG query types
+      # both use nil for schema queries and non schema queries
+      SCHEMA_QUERY_TYPES = ["Sequence", "Primary Key", "Primary Key Trigger", "SCHEMA"].freeze
+
+      IGNORED_PAYLOAD=%w(EXPLAIN CACHE)
+      def ignore_payload?(payload)
+        payload[:exception] ||
+        (Rack::MiniProfiler.config.skip_schema_queries and SCHEMA_QUERY_TYPES.include?(payload[:name])) ||
+        %w(EXPLAIN CACHE).include?(payload[:name])
+      end
+    end
+
+    def self.subscribe_sql_notifications
+      logger = ::Rack::MiniProfiler::ActiveRecordLogger.new
+      %w(sql.active_record).each do |event|
+        ActiveSupport::Notifications.subscribe(event, logger)
+      end
+    end
+  end
+end
+
+::Rack::MiniProfiler.subscribe_sql_notifications


### PR DESCRIPTION
This is what I had in mind for #199 -- leveraging active support notifications.

This is working for me in rails 3 and 5.

`ActiveRecord` already depends upon `ActiveSupport` and is already generating these events. So this doesn't seem to be adding any additional dependencies or overhead.

Left removing the active record patches as a separate commit so can add those back in if you like.
