### PR TITLE
Removes `alias_method_chain` in Mongo patch for Rails 5 deprecation warning

### DIFF
--- a/lib/patches/db/mongo.rb
+++ b/lib/patches/db/mongo.rb
@@ -8,5 +8,9 @@ class Mongo::Server::Connection
     end
     return result
   end
-  alias_method_chain :dispatch, :timing
+
+  # TODO: change to Module#prepend as soon as Ruby 1.9.3 support is dropped
+  alias_method :dispatch_without_timing, :dispatch
+  alias_method :dispatch, :dispatch_with_timing
+
 end


### PR DESCRIPTION
Rails 5 issues a deprecation warning when using `alias_method_chain` favoring `Module#prepend`.  `Module#prepend` wasn't introduced until Ruby 2.0, but since we still support 1.9.3, we can't easily switch.

Since `alias_method_chain` was just encapsulating the pattern of using two `alias_method` calls, we can remove the deprecation warning and support Ruby 1.9.3 by just using the two `alias_method` calls that were created.  I've left a `TODO:` in the code to note that we should switch this out to use `Module#prepend` once Ruby 1.9.3 support is dropped.

@kbrock is correct in his comments that using `Module#prepend` and `alias_method_chain` would have to be structured very differently and once I started down that road, it didn't seem to be worth it -- at least at this point in time.  We're not *losing* anything by switching to two `alias_method` calls, though we aren't *gaining* much either (a single deprecation warning).

This addresses the comments brought up in #196 (which can now be closed since the main issue was resolved in #201).
