### PR TITLE
Remove singleton_class method

### DIFF
--- a/lib/mini_profiler/profiling_methods.rb
+++ b/lib/mini_profiler/profiling_methods.rb
@@ -110,11 +110,11 @@ module Rack
       end
 
       def profile_singleton_method(klass, method, type = :profile, &blk)
-        profile_method(singleton_class(klass), method, type, &blk)
+        profile_method(klass.singleton_class, method, type, &blk)
       end
 
       def unprofile_singleton_method(klass, method)
-        unprofile_method(singleton_class(klass), method)
+        unprofile_method(klass.singleton_class, method)
       end
 
       # Add a custom timing. These are displayed similar to SQL/query time in
@@ -141,10 +141,6 @@ module Rack
       end
 
       private
-
-      def singleton_class(klass)
-        class << klass; self; end
-      end
 
       def clean_method_name(method)
         method.to_s.gsub(/[\?\!]/, "")


### PR DESCRIPTION
It's not needed since Ruby < 1.9.3 isn't supported.

#215