### PR TITLE
Just using defined

### DIFF
--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -8,20 +8,8 @@ class SqlPatches
     @patched = val
   end
 
-  def self.class_exists?(name)
-    eval(name + ".class").to_s.eql?('Class')
-  rescue NameError
-    false
-  end
-
   def self.correct_version?(required_version, klass)
     Gem::Dependency.new('', required_version).match?('', klass::VERSION)
-  rescue NameError
-    false
-  end
-
-  def self.module_exists?(name)
-    eval(name + ".class").to_s.eql?('Module')
   rescue NameError
     false
   end
@@ -43,15 +31,15 @@ class SqlPatches
   end
 end
 
-require 'patches/db/mysql2'           if defined?(Mysql2::Client) && SqlPatches.class_exists?("Mysql2::Client")
-require 'patches/db/pg'               if defined?(PG::Result) && SqlPatches.class_exists?("PG::Result")
-require 'patches/db/oracle_enhanced'  if defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter) && SqlPatches.class_exists?("ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter") && SqlPatches.correct_version?('~> 1.5.0', ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
-require 'patches/db/mongo'            if defined?(Mongo) && SqlPatches.module_exists?("Mongo")
-require 'patches/db/moped'            if defined?(Moped::Node) && SqlPatches.class_exists?("Moped::Node")
-require 'patches/db/plucky'           if defined?(Plucky::Query) && SqlPatches.class_exists?("Plucky::Query")
-require 'patches/db/rsolr'            if defined?(RSolr::Connection) && SqlPatches.class_exists?("RSolr::Connection") && RSolr::VERSION[0] != "0"
-require 'patches/db/sequel'           if defined?(Sequel::Database) && !SqlPatches.patched? && SqlPatches.class_exists?("Sequel::Database")
-require 'patches/db/activerecord'     if defined?(ActiveRecord) &&!SqlPatches.patched? && SqlPatches.module_exists?("ActiveRecord")
-require 'patches/db/nobrainer'        if defined?(NoBrainer) && SqlPatches.module_exists?("NoBrainer")
-require 'patches/db/riak'             if defined?(Riak) && SqlPatches.module_exists?("Riak")
-require 'patches/db/neo4j'            if defined?(Neo4j::Core) && SqlPatches.class_exists?("Neo4j::Core::Query")
+require 'patches/db/mysql2'           if defined?(Mysql2::Client)
+require 'patches/db/pg'               if defined?(PG::Result)
+require 'patches/db/oracle_enhanced'  if defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter) && SqlPatches.correct_version?('~> 1.5.0', ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
+require 'patches/db/mongo'            if defined?(Mongo)
+require 'patches/db/moped'            if defined?(Moped::Node)
+require 'patches/db/plucky'           if defined?(Plucky::Query)
+require 'patches/db/rsolr'            if defined?(RSolr::Connection) && RSolr::VERSION[0] != "0"
+require 'patches/db/sequel'           if defined?(Sequel::Database) && !SqlPatches.patched?
+require 'patches/db/activerecord'     if defined?(ActiveRecord) && !SqlPatches.patched?
+require 'patches/db/nobrainer'        if defined?(NoBrainer)
+require 'patches/db/riak'             if defined?(Riak)
+require 'patches/db/neo4j'            if defined?(Neo4j::Core)


### PR DESCRIPTION
I would imaging that just using `defined?` would be sufficient to know if a gem was imported without
resorting to testing whether it is a `class` or `module`.

Well, that is my interpretation of the code that introduced this method: af73d1255473af0cff9c5f02b429a49c755a0597

But it is very possible that I don't understand the nuances that you were targeting.
Thanks