### PR TITLE
Fix PATH_INFO starting with double slashes

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -120,7 +120,8 @@ module Rack
     end
 
     def serve_html(env)
-      file_name = env['PATH_INFO'][(@config.base_url_path.length)..1000]
+      path      = env['PATH_INFO'].sub('//', '/')
+      file_name = path.sub(@config.base_url_path, '')
 
       return serve_results(env) if file_name.eql?('results')
 
@@ -152,7 +153,7 @@ module Rack
 
       status = headers = body = nil
       query_string = env['QUERY_STRING']
-      path         = env['PATH_INFO']
+      path         = env['PATH_INFO'].sub('//', '/')
 
       # Someone (e.g. Rails engine) could change the SCRIPT_NAME so we save it
       env['RACK_MINI_PROFILER_ORIGINAL_SCRIPT_NAME'] = env['SCRIPT_NAME']


### PR DESCRIPTION
Apparently when using the profiler from mounted routes the variable `env['PATH_INFO']` would come starting with two slashes `//` which caused conditionals like `starts_with?` and other comparisons to fail.

Tests ran OK except the ones that needed redis and memcache - since I didn't have those installed.

Fixed #114.
