### PR TITLE
Define directly

### DIFF
--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -1,4 +1,7 @@
 class SqlPatches
+  def self.unpatched?
+    !patched?
+  end
 
   def self.patched?
     @patched
@@ -50,8 +53,8 @@ require 'patches/db/mongo'            if defined?(Mongo) && SqlPatches.module_ex
 require 'patches/db/moped'            if defined?(Moped::Node) && SqlPatches.class_exists?("Moped::Node")
 require 'patches/db/plucky'           if defined?(Plucky::Query) && SqlPatches.class_exists?("Plucky::Query")
 require 'patches/db/rsolr'            if defined?(RSolr::Connection) && SqlPatches.class_exists?("RSolr::Connection") && RSolr::VERSION[0] != "0"
-require 'patches/db/sequel'           if defined?(Sequel::Database) && !SqlPatches.patched? && SqlPatches.class_exists?("Sequel::Database")
-require 'patches/db/activerecord'     if defined?(ActiveRecord) &&!SqlPatches.patched? && SqlPatches.module_exists?("ActiveRecord")
+require 'patches/db/sequel'           if defined?(Sequel::Database) && SqlPatches.unpatched? && SqlPatches.class_exists?("Sequel::Database")
+require 'patches/db/activerecord'     if defined?(ActiveRecord) && SqlPatches.unpatched? && SqlPatches.module_exists?("ActiveRecord")
 require 'patches/db/nobrainer'        if defined?(NoBrainer) && SqlPatches.module_exists?("NoBrainer")
 require 'patches/db/riak'             if defined?(Riak) && SqlPatches.module_exists?("Riak")
 require 'patches/db/neo4j'            if defined?(Neo4j::Core) && SqlPatches.class_exists?("Neo4j::Core::Query")

--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -11,20 +11,8 @@ class SqlPatches
     @patched = val
   end
 
-  def self.class_exists?(name)
-    eval(name + ".class").to_s.eql?('Class')
-  rescue NameError
-    false
-  end
-
   def self.correct_version?(required_version, klass)
     Gem::Dependency.new('', required_version).match?('', klass::VERSION)
-  rescue NameError
-    false
-  end
-
-  def self.module_exists?(name)
-    eval(name + ".class").to_s.eql?('Module')
   rescue NameError
     false
   end
@@ -46,15 +34,15 @@ class SqlPatches
   end
 end
 
-require 'patches/db/mysql2'           if defined?(Mysql2::Client) && SqlPatches.class_exists?("Mysql2::Client")
-require 'patches/db/pg'               if defined?(PG::Result) && SqlPatches.class_exists?("PG::Result")
-require 'patches/db/oracle_enhanced'  if defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter) && SqlPatches.class_exists?("ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter") && SqlPatches.correct_version?('~> 1.5.0', ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
-require 'patches/db/mongo'            if defined?(Mongo) && SqlPatches.module_exists?("Mongo")
-require 'patches/db/moped'            if defined?(Moped::Node) && SqlPatches.class_exists?("Moped::Node")
-require 'patches/db/plucky'           if defined?(Plucky::Query) && SqlPatches.class_exists?("Plucky::Query")
-require 'patches/db/rsolr'            if defined?(RSolr::Connection) && SqlPatches.class_exists?("RSolr::Connection") && RSolr::VERSION[0] != "0"
-require 'patches/db/sequel'           if defined?(Sequel::Database) && SqlPatches.unpatched? && SqlPatches.class_exists?("Sequel::Database")
-require 'patches/db/activerecord'     if defined?(ActiveRecord) && SqlPatches.unpatched? && SqlPatches.module_exists?("ActiveRecord")
-require 'patches/db/nobrainer'        if defined?(NoBrainer) && SqlPatches.module_exists?("NoBrainer")
-require 'patches/db/riak'             if defined?(Riak) && SqlPatches.module_exists?("Riak")
-require 'patches/db/neo4j'            if defined?(Neo4j::Core) && SqlPatches.class_exists?("Neo4j::Core::Query")
+require 'patches/db/mysql2'           if defined?(Mysql2::Client) && Mysql2::Client.class == Class
+require 'patches/db/pg'               if defined?(PG::Result) && PG::Result.class == Class
+require 'patches/db/oracle_enhanced'  if defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter) && ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.class == Class && SqlPatches.correct_version?('~> 1.5.0', ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
+require 'patches/db/mongo'            if defined?(Mongo) && Mongo.class == Module
+require 'patches/db/moped'            if defined?(Moped::Node) && Moped::Node.class == Class
+require 'patches/db/plucky'           if defined?(Plucky::Query) && Plucky::Query.class == Class
+require 'patches/db/rsolr'            if defined?(RSolr::Connection) && RSolr::Connection.class == Class && RSolr::VERSION[0] != "0"
+require 'patches/db/sequel'           if SqlPatches.unpatched? && defined?(Sequel::Database) && Sequel::Database.class == Class
+require 'patches/db/activerecord'     if SqlPatches.unpatched? && defined?(ActiveRecord) && ActiveRecord.class == Module
+require 'patches/db/nobrainer'        if defined?(NoBrainer) && NoBrainer.class == Module
+require 'patches/db/riak'             if defined?(Riak) && Riak.class == Module
+require 'patches/db/neo4j'            if defined?(Neo4j::Core) && Neo4j::Core::Query.class == ClassQuery

--- a/spec/components/sql_patches_spec.rb
+++ b/spec/components/sql_patches_spec.rb
@@ -28,32 +28,4 @@ describe SqlPatches do
       expect(SqlPatches).to be_unpatched
     end
   end
-
-  describe ".class_exists?(name)" do
-    it "detects non-existant" do
-      expect(SqlPatches.class_exists?("SomeRandomClassThatDoesntExist")).to eq(false)
-    end
-
-    it "detects module" do
-      expect(SqlPatches.class_exists?("Rack")).to eq(false)
-    end
-
-    it "detects class" do
-      expect(SqlPatches.class_exists?("SqlPatches")).to eq(true)
-    end
-  end
-
-  describe ".module_exists?(name)" do
-    it "detects non-existant" do
-      expect(SqlPatches.module_exists?("SomeRandomClassThatDoesntExist")).to eq(false)
-    end
-
-    it "detects module" do
-      expect(SqlPatches.module_exists?("Rack")).to eq(true)
-    end
-
-    it "detects class" do
-      expect(SqlPatches.module_exists?("SqlPatches")).to eq(false)
-    end
-  end
 end

--- a/spec/components/sql_patches_spec.rb
+++ b/spec/components/sql_patches_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe SqlPatches do
+  # and patched= to some extent
+  describe ".patched?" do
+    it "detects patched" do
+      SqlPatches.patched = true
+
+      expect(SqlPatches).to be_patched
+    end
+
+    it "detects unpatched" do
+      SqlPatches.patched = false
+
+      expect(SqlPatches).not_to be_patched
+    end
+  end
+
+  describe ".unpatched?" do
+    it "detects patched" do
+      SqlPatches.patched = true
+
+      expect(SqlPatches).not_to be_unpatched
+    end
+
+    it "detects unpatched" do
+      SqlPatches.patched = false
+      expect(SqlPatches).to be_unpatched
+    end
+  end
+
+  describe ".class_exists?(name)" do
+    it "detects non-existant" do
+      expect(SqlPatches.class_exists?("SomeRandomClassThatDoesntExist")).to eq(false)
+    end
+
+    it "detects module" do
+      expect(SqlPatches.class_exists?("Rack")).to eq(false)
+    end
+
+    it "detects class" do
+      expect(SqlPatches.class_exists?("SqlPatches")).to eq(true)
+    end
+  end
+
+  describe ".module_exists?(name)" do
+    it "detects non-existant" do
+      expect(SqlPatches.module_exists?("SomeRandomClassThatDoesntExist")).to eq(false)
+    end
+
+    it "detects module" do
+      expect(SqlPatches.module_exists?("Rack")).to eq(true)
+    end
+
+    it "detects class" do
+      expect(SqlPatches.module_exists?("SqlPatches")).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
You said performance...

Here is an alternative to #231 that you may like:

- Much more performant
- Reduces source code
- Removes the `eval` all together
- levarages `unpatched` from #232.

### Algorithm

Instead of having a method to check the class, just define it inline. And don't eval it.

### Benchmark

class defined|before|after
-----|---|---
yes|180k/s|6.328M/s
no|6M/s|7.565M/s

Details can be found in [benchmark]. Before is using `define?` and `eval`. After is `defined?` and a direct `.class` call.
 
[benchmark]: https://gist.github.com/kbrock/edd05b8e4b463eda07082e2efa33e6f2

### ASIDE

This is getting similar to #225 (which I still like most of all the choices)

If another of the ideas from the [benchmark]() tickle your fancy, let me know.

[benchmark]: https://gist.github.com/kbrock/edd05b8e4b463eda07082e2efa33e6f2