### PR TITLE
access environment from passed values

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -575,10 +575,10 @@ Append the following to your query string:
     # * you have disabled auto append behaviour throught :auto_inject => false flag
     # * you do not want script to be automatically appended for the current page. You can also call cancel_auto_inject
     def get_profile_script(env)
-      path = if ENV["PASSENGER_BASE_URI"] then
+      path = if env["PASSENGER_BASE_URI"] then
         # added because the SCRIPT_NAME workaround below then
         # breaks running under a prefix as permitted by Passenger. 
-        "#{ENV['PASSENGER_BASE_URI']}#{@config.base_url_path}"
+        "#{env['PASSENGER_BASE_URI']}#{@config.base_url_path}"
       elsif env["action_controller.instance"]
         # Rails engines break SCRIPT_NAME; the following appears to discard SCRIPT_NAME
         # since url_for appears documented to return any String argument unmodified

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -63,7 +63,7 @@ describe Rack::MiniProfiler do
       map '/under_passenger' do
         run lambda { |env|
           env['SCRIPT_NAME'] = '/under_passenger'
-          ENV['PASSENGER_BASE_URI'] = '/under_passenger'
+          env['PASSENGER_BASE_URI'] = '/under_passenger'
           [200, {'Content-Type' => 'text/html'}, '<html><h1>and I ride and I ride</h1></html>']
         }
       end


### PR DESCRIPTION
This is blind, and more of a question than anything else.

@nspring Is there a reason for accessing `ENV` instead of `env` here?
This is the only use of `ENV` in the code base and potentially makes the tests fragile to modify the global environment.

Thanks for any insight