### PR TITLE
fix multi edit fail for Neo4j

### DIFF
--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -45,4 +45,4 @@ require 'patches/db/sequel'           if SqlPatches.unpatched? && defined?(Seque
 require 'patches/db/activerecord'     if SqlPatches.unpatched? && defined?(ActiveRecord) && ActiveRecord.class == Module
 require 'patches/db/nobrainer'        if defined?(NoBrainer) && NoBrainer.class == Module
 require 'patches/db/riak'             if defined?(Riak) && Riak.class == Module
-require 'patches/db/neo4j'            if defined?(Neo4j::Core) && Neo4j::Core::Query.class == ClassQuery
+require 'patches/db/neo4j'            if defined?(Neo4j::Core) && Neo4j::Core::Query.class == Class


### PR DESCRIPTION
So sorry this slipped through. (sublime multi cursor fail)

Do you have ideas on how to prevent this error?
Define all of these patches in a module and include into classes if they are defined? (instead of direct monkey patches?)

e.g. make more similar to activerecord.

Is there a point in time that you want to drop 1.9.3 and use module prepend? (sorry, can't remember your stance here)
