### PR TITLE
active record add instrumentation in common way

### DIFF
--- a/lib/patches/db/activerecord.rb
+++ b/lib/patches/db/activerecord.rb
@@ -39,15 +39,13 @@ module Rack
         rval
       end
     end
-  end
 
-  def self.insert_instrumentation
-    ActiveRecord::ConnectionAdapters::AbstractAdapter.module_eval do
-      include ::Rack::MiniProfiler::ActiveRecordInstrumentation
+    def self.insert_ar_instrumentation
+      ActiveRecord::ConnectionAdapters::AbstractAdapter.module_eval do
+        include ::Rack::MiniProfiler::ActiveRecordInstrumentation
+      end
     end
   end
-
-  if defined?(::Rails) && !SqlPatches.patched?
-    insert_instrumentation
-  end
 end
+
+::Rack::MiniProfiler.insert_ar_instrumentation

--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -42,7 +42,7 @@ require 'patches/db/moped'            if defined?(Moped::Node) && Moped::Node.cl
 require 'patches/db/plucky'           if defined?(Plucky::Query) && Plucky::Query.class == Class
 require 'patches/db/rsolr'            if defined?(RSolr::Connection) && RSolr::Connection.class == Class && RSolr::VERSION[0] != "0"
 require 'patches/db/sequel'           if SqlPatches.unpatched? && defined?(Sequel::Database) && Sequel::Database.class == Class
-require 'patches/db/activerecord'     if SqlPatches.unpatched? && defined?(ActiveRecord) && ActiveRecord.class == Module
+require 'patches/db/activerecord'     if SqlPatches.unpatched? && defined?(ActiveRecord) && defined?(::Rails) && ActiveRecord.class == Module
 require 'patches/db/nobrainer'        if defined?(NoBrainer) && NoBrainer.class == Module
 require 'patches/db/riak'             if defined?(Riak) && Riak.class == Module
 require 'patches/db/neo4j'            if defined?(Neo4j::Core) && Neo4j::Core::Query.class == Class


### PR DESCRIPTION
a few thoughts:

1. I like the way this adds a module rather than monkey patching the classes directly.
2. This can be easily changed to module prepend
3. The pattern seems to be to check `patched?` and defined? outside the class.
4. Not sure why we are ensuring `Rails` is defined.

Questions:

1. Would it make sense to have all the patches work the same way?
(I'd be happy to implement this, but would be flying by the seat of my pants as I do not have most of these systems installed)
2. At a future time, would we want to remove the inject logic from the bottom of the patch file. Instead, all patches could be required, but sql_patches would apply the desired patch.
