### PR TITLE
Fix Travis builds failing due to Guard dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.7
-  - 2.2.3
+  - 2.2.5
+  - 2.3.1
+before_install:
+   - gem install bundler
 services:
   - redis
   - memcached

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,8 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'codecov', :require => false, :group => :test
+
+group :development do
+  gem 'guard', :platforms => [:mri_22, :mri_23]
+  gem 'guard-rspec', :platforms => [:mri_22, :mri_23]
+end

--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -30,8 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'therubyracer'
   s.add_development_dependency 'less'
   s.add_development_dependency 'flamegraph'
-  s.add_development_dependency 'guard'
-  s.add_development_dependency 'guard-rspec'
 
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
This PR gets Travis tests working for all Rubies by moving the `guard` development dependency to the Gemfile so `:platforms` can restrict it to Ruby 2.2+.

It also adds Ruby 2.3 to the build matrix and ensures `bundler` is up-to-date enough to know about `:mri_22` and `:mri_23` platforms.