### PR TITLE
Resolve circular reference issue while generating JSON with Oj

### DIFF
--- a/lib/mini_profiler/timer_struct/base.rb
+++ b/lib/mini_profiler/timer_struct/base.rb
@@ -27,6 +27,9 @@ module Rack
           ::JSON.generate( @attributes, :max_nesting => 100 )
         end
 
+        def as_json(options = nil)
+          @attributes.as_json(options)
+        end
       end
     end
   end

--- a/lib/mini_profiler/timer_struct/page.rb
+++ b/lib/mini_profiler/timer_struct/page.rb
@@ -57,12 +57,19 @@ module Rack
         end
 
         def to_json(*a)
-          attribs = @attributes.merge(
+          ::JSON.generate(@attributes.merge(self.extra_json))
+        end
+
+        def as_json(options = nil)
+          super(options).merge!(extra_json)
+        end
+
+        def extra_json
+          {
             :started               => '/Date(%d)/' % @attributes[:started],
             :duration_milliseconds => @attributes[:root][:duration_milliseconds],
             :custom_timing_names   => @attributes[:custom_timing_stats].keys.sort
-          )
-          ::JSON.generate(attribs, :max_nesting => 100)
+          }
         end
       end
     end


### PR DESCRIPTION
This PR addresses the problem identified in #70 where `oj_mimic_json` prevents the JSON response from being created.

Oj prefers `as_json` to `to_json` and previously the TimerStruct classes only implemented `to_json`. This commit adds `as_json` support that matches the `to_json` implementation so either way will work.

Specifically, the circular reference is between Page and Request (TimerStruct) objects where Page has reference to a `@attributes[:root]` Request and Request has a `@page` attribute.

I have not added test cases for this new code because `as_json` will only work if ActiveSupport extensions have loaded so that Hash has `as_json` support. The fix can be verified by adding the `oj_mimic_json` gem to an existing app.