### PR TITLE
use File.exist? instead of deprecated File.exists?

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ c.pre_authorize_cb = lambda { |env|
   Rails.env.development? || Rails.env.production?
 }
 tmp = Rails.root.to_s + "/tmp/miniprofiler"
-FileUtils.mkdir_p(tmp) unless File.exists?(tmp)
+FileUtils.mkdir_p(tmp) unless File.exist?(tmp)
 c.storage_options = {:path => tmp}
 c.storage = ::Rack::MiniProfiler::FileStore
 config.middleware.use(::Rack::MiniProfiler)

--- a/lib/mini_profiler/storage/file_store.rb
+++ b/lib/mini_profiler/storage/file_store.rb
@@ -44,7 +44,7 @@ module Rack
         @path = args[:path]
         @expires_in_seconds = args[:expires_in] || EXPIRES_IN_SECONDS
         raise ArgumentError.new :path unless @path
-        FileUtils.mkdir_p(@path) unless ::File.exists?(@path)
+        FileUtils.mkdir_p(@path) unless ::File.exist?(@path)
 
         @timer_struct_cache = FileCache.new(@path, "mp_timers")
         @timer_struct_lock  = Mutex.new

--- a/spec/lib/storage/file_store_spec.rb
+++ b/spec/lib/storage/file_store_spec.rb
@@ -5,7 +5,7 @@ describe Rack::MiniProfiler::FileStore do
 
     before do
       tmp = File.expand_path(__FILE__ + "/../../../tmp")
-      Dir::mkdir(tmp) unless File.exists?(tmp)
+      Dir::mkdir(tmp) unless File.exist?(tmp)
       @store = Rack::MiniProfiler::FileStore.new(:path => tmp)
     end
 


### PR DESCRIPTION
`File.exists?` was deprecated in Ruby 2.1. Ref: https://github.com/ruby/ruby/blob/v2_1_2/file.c#L1413