### PR TITLE
pull out full_stacktrace logging logic

### DIFF
--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -9,12 +9,14 @@ module Rack
           stack_trace = nil
           unless skip_backtrace || duration_ms < Rack::MiniProfiler.config.backtrace_threshold_ms
             # Allow us to filter the stack trace
-            stack_trace = ""
+            if full_backtrace
+              stack_trace = Kernel.caller.join "\n"
+            else
+              stack_trace = ""
              # Clean up the stack trace if there are options to do so
-            Kernel.caller.each do |ln|
-              ln.gsub!(Rack::MiniProfiler.config.backtrace_remove, '') if Rack::MiniProfiler.config.backtrace_remove and !full_backtrace
-              if    full_backtrace or
-                    (
+              Kernel.caller.each do |ln|
+                ln.gsub!(Rack::MiniProfiler.config.backtrace_remove, '') if Rack::MiniProfiler.config.backtrace_remove
+                if (
                       (
                         Rack::MiniProfiler.config.backtrace_includes.nil? or
                         Rack::MiniProfiler.config.backtrace_includes.any?{|regex| ln =~ regex}
@@ -24,7 +26,8 @@ module Rack
                         Rack::MiniProfiler.config.backtrace_ignores.none?{|regex| ln =~ regex}
                       )
                     )
-                stack_trace << ln << "\n"
+                  stack_trace << ln << "\n"
+                end
               end
             end
           end

--- a/spec/lib/timer_struct/sql_timer_struct_spec.rb
+++ b/spec/lib/timer_struct/sql_timer_struct_spec.rb
@@ -21,8 +21,6 @@ describe Rack::MiniProfiler::TimerStruct::Sql do
     end
   end
 
-
-
   describe 'backtrace' do
     it 'has a snippet' do
       sql = Rack::MiniProfiler::TimerStruct::Sql.new("SELECT * FROM users", 200, @page, nil)
@@ -34,14 +32,15 @@ describe Rack::MiniProfiler::TimerStruct::Sql do
       sql[:stack_trace_snippet].should match /rspec/
     end
 
-    it "doesn't include rspec if we filter for only app" do
-      Rack::MiniProfiler.config.backtrace_includes = [/\/app/]
+    it "doesn't include rspec if we filter for only rack-mini-profiler" do
+      Rack::MiniProfiler.config.backtrace_includes = [/\/rack-mini-profiler/]
       sql = Rack::MiniProfiler::TimerStruct::Sql.new("SELECT * FROM users", 200, @page, nil)
       sql[:stack_trace_snippet].should_not match /rspec/
+      sql[:stack_trace_snippet].should match /rack-mini-profiler/
     end
 
     it "includes rspec if we filter for it" do
-      Rack::MiniProfiler.config.backtrace_includes = [/\/(app|rspec)/]
+      Rack::MiniProfiler.config.backtrace_includes = [/\/(rack-mini-profiler|rspec)/]
       sql = Rack::MiniProfiler::TimerStruct::Sql.new("SELECT * FROM users", 200, @page, nil)
       sql[:stack_trace_snippet].should match /rspec/
     end


### PR DESCRIPTION
Noticed `full_backtrace` was on each of the lines for trimming the backtrace.
So I split that logic to what I find easier to read.

In the end, this this is just a minor change.
(I had bigger plans like using `Regexp.join()` didn't get the performance boost I had wanted.)

Thanks
