### PR TITLE
Allow environment variable to define sql patching

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,29 @@ class MyApp < Sinatra::Base
 end
 ```
 
+#### Patching ActiveRecord
+
+A typical web application spends a lot of time querying the database. rack_mini_profiler will detect the ORM that is available
+and apply patches to properly collect query statistics.
+
+To make this work, declare the orm's gem before declaring `rack-mini-profiler` in the `Gemfile`:
+
+```ruby
+gem 'pg'
+gem 'mongoid'
+gem 'rack-mini-profiler'
+
+```
+
+If you wish to override this behavior, the environment variable `RACK_MINI_PROFILER_PATCH` is available.
+
+```bash
+export RACK_MINI_PROFILER_PATCH="pg,mongoid"
+# or
+export RACK_MINI_PROFILER_PATCH="false"
+# initializers/rack_profiler.rb: SqlPatches.patch %w(mongo)
+```
+
 ### Flamegraphs
 
 To generate [flamegraphs](http://samsaffron.com/archive/2013/03/19/flame-graphs-in-ruby-miniprofiler):

--- a/lib/patches/db/activerecord.rb
+++ b/lib/patches/db/activerecord.rb
@@ -47,7 +47,7 @@ module Rack
     end
   end
 
-  if defined?(::Rails) && !SqlPatches.patched?
+  if defined?(::Rails)
     insert_instrumentation
   end
 end

--- a/lib/patches/db/mysql2.rb
+++ b/lib/patches/db/mysql2.rb
@@ -26,5 +26,3 @@ class Mysql2::Client
     result
   end
 end
-
-SqlPatches.patched = true

--- a/lib/patches/db/oracle_enhanced.rb
+++ b/lib/patches/db/oracle_enhanced.rb
@@ -66,5 +66,3 @@ class ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter
     !(Rack::MiniProfiler.config.skip_schema_queries && SCHEMA_QUERY_TYPES.include?(name))
   end
 end
-
-SqlPatches.patched = true

--- a/lib/patches/db/pg.rb
+++ b/lib/patches/db/pg.rb
@@ -100,5 +100,3 @@ class PG::Connection
 
   alias_method :query, :exec
 end
-
-SqlPatches.patched = true

--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -1,16 +1,4 @@
 class SqlPatches
-  def self.unpatched?
-    !patched?
-  end
-
-  def self.patched?
-    @patched
-  end
-
-  def self.patched=(val)
-    @patched = val
-  end
-
   def self.correct_version?(required_version, klass)
     Gem::Dependency.new('', required_version).match?('', klass::VERSION)
   rescue NameError
@@ -32,17 +20,45 @@ class SqlPatches
   def self.elapsed_time(start_time)
     ((Time.now - start_time).to_f * 1000).round(1)
   end
+
+  def self.sql_patches
+    patches = []
+
+    patches << 'mysql2' if defined?(Mysql2::Client) && Mysql2::Client.class == Class
+    patches << 'pg' if defined?(PG::Result) && PG::Result.class == Class
+    patches << 'oracle_enhanced' if defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter) && ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.class == Class &&
+                                    SqlPatches.correct_version?('~> 1.5.0', ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
+    # if the adapters were directly patched, don't patch again
+    return patches unless patches.empty?
+    patches << 'sequel' if defined?(Sequel::Database) && Sequel::Database.class == Class
+    patches << 'activerecord' if defined?(ActiveRecord) && ActiveRecord.class == Module
+
+    patches
+  end
+
+  def self.other_patches
+    patches = []
+    patches << 'mongo' if defined?(Mongo::Server::Connection) && Mongo.class == Module
+    patches << 'moped' if defined?(Moped::Node) && Moped::Node.class == Class
+    patches << 'plucky' if defined?(Plucky::Query) && Plucky::Query.class == Class
+    patches << 'rsolr' if defined?(RSolr::Connection) && RSolr::Connection.class == Class && RSolr::VERSION[0] != "0"
+    patches << 'nobrainer' if defined?(NoBrainer) && NoBrainer.class == Module
+    patches << 'riak' if defined?(Riak) && Riak.class == Module
+    patches << 'neo4j' if defined?(Neo4j::Core) && Neo4j::Core::Query.class == Class
+    patches
+  end
+
+  def self.all_patch_files
+    env_var = ENV["RACK_MINI_PROFILER_PATCH"]
+    return [] if env_var == "false"
+    env_var ? env_var.split(",").map(&:strip) : sql_patches + other_patches
+  end
+
+  def self.patch(patch_files = all_patch_files)
+    patch_files.each do |patch_file|
+      require "patches/db/#{patch_file}"
+    end
+  end
 end
 
-require 'patches/db/mysql2'           if defined?(Mysql2::Client) && Mysql2::Client.class == Class
-require 'patches/db/pg'               if defined?(PG::Result) && PG::Result.class == Class
-require 'patches/db/oracle_enhanced'  if defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter) && ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.class == Class && SqlPatches.correct_version?('~> 1.5.0', ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter)
-require 'patches/db/mongo'            if defined?(Mongo::Server::Connection) && Mongo.class == Module
-require 'patches/db/moped'            if defined?(Moped::Node) && Moped::Node.class == Class
-require 'patches/db/plucky'           if defined?(Plucky::Query) && Plucky::Query.class == Class
-require 'patches/db/rsolr'            if defined?(RSolr::Connection) && RSolr::Connection.class == Class && RSolr::VERSION[0] != "0"
-require 'patches/db/sequel'           if SqlPatches.unpatched? && defined?(Sequel::Database) && Sequel::Database.class == Class
-require 'patches/db/activerecord'     if SqlPatches.unpatched? && defined?(ActiveRecord) && ActiveRecord.class == Module
-require 'patches/db/nobrainer'        if defined?(NoBrainer) && NoBrainer.class == Module
-require 'patches/db/riak'             if defined?(Riak) && Riak.class == Module
-require 'patches/db/neo4j'            if defined?(Neo4j::Core) && Neo4j::Core::Query.class == Class
+SqlPatches.patch


### PR DESCRIPTION
When users introduce their own patches, or want to work around
patch detection, this allows them to override with
`$RACK_MINI_PROFILER_PATCH`

setting to `"false"` skips sql patches all together

