### PR TITLE
For older version of ruby, use older rack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ gemspec
 
 gem 'codecov', :require => false, :group => :test
 
+if RUBY_VERSION < '2.2.2'
+  gem 'rack', '1.6.4'
+end
+
 group :development do
   gem 'guard', :platforms => [:mri_22, :mri_23]
   gem 'guard-rspec', :platforms => [:mri_22, :mri_23]


### PR DESCRIPTION
Rack `2.0.1` requires a more recent version of ruby.

Trying to work around this and still support  older versions of ruby