### PR TITLE
Use earlier version of json for ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ gemspec
 
 gem 'codecov', :require => false, :group => :test
 
+if RUBY_VERSION < '2.0.0'
+  gem 'json', '~>1.8'
+end
+
 if RUBY_VERSION < '2.2.2'
   gem 'rack', '1.6.4'
 end


### PR DESCRIPTION
Current version of the json gem requires ruby 2.0
