### PR TITLE
Disable compression on profiled requests for simpler configuration

### DIFF
--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -18,7 +18,7 @@ module Rack
       :flamegraph_sample_rate, :logger, :pre_authorize_cb, :skip_paths,
       :skip_schema_queries, :storage, :storage_failure, :storage_instance,
       :storage_options, :user_provider
-    attr_accessor :skip_sql_param_names, :max_sql_param_length
+    attr_accessor :skip_sql_param_names, :suppress_encoding, :max_sql_param_length
 
     # ui accessors
     attr_accessor :collapse_results, :max_traces_to_show, :position,

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -253,6 +253,10 @@ module Rack
           env['HTTP_IF_NONE_MATCH']     = ''
         end
 
+        orig_accept_encoding = env['HTTP_ACCEPT_ENCODING']
+        # Prevent response body from being compressed
+        env['HTTP_ACCEPT_ENCODING'] = 'identity' if config.suppress_encoding
+
         if query_string =~ /pp=flamegraph/
           unless defined?(Flamegraph) && Flamegraph.respond_to?(:generate)
 
@@ -279,6 +283,7 @@ module Rack
         end
       ensure
         trace.disable if trace
+        env['HTTP_ACCEPT_ENCODING'] = orig_accept_encoding if config.suppress_encoding
       end
 
       skip_it = current.discard

--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -88,6 +88,17 @@ module Rack::MiniProfilerRails
       Rack::MiniProfilerRails.initialize!(app)
     end
 
+    # Suppress compression when Rack::Deflater is lower in the middleware
+    # stack than Rack::MiniProfiler
+    initializer "rack_mini_profiler.after_build_middleware", :after => :build_middleware_stack do |app|
+      middlewares = app.middleware.middlewares
+      if Rack::MiniProfiler.config.suppress_encoding.nil? &&
+          middlewares.include?(Rack::Deflater) &&
+          middlewares.index(Rack::Deflater) > middlewares.index(Rack::MiniProfiler)
+        Rack::MiniProfiler.config.suppress_encoding = true
+      end
+    end
+
     # TODO: Implement something better here
     # config.after_initialize do
     #

--- a/spec/integration/middleware_spec.rb
+++ b/spec/integration/middleware_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+require 'rack-mini-profiler'
+require 'rack/test'
+require 'zlib'
+
+describe Rack::MiniProfiler do
+  include Rack::Test::Methods
+
+  before(:each) { Rack::MiniProfiler.reset_config }
+
+  def do_get(params={})
+    get '/html', params, { 'HTTP_ACCEPT_ENCODING' => 'gzip, compress' }
+  end
+
+  def decompressed_response
+    Zlib::GzipReader.new(StringIO.new(last_response.body)).read
+  end
+
+  shared_examples 'should not affect a skipped requests' do
+    it 'should not affect a skipped requests' do
+      do_get(:pp=>'skip')
+      expect(last_response.headers).to include('Content-Encoding')
+      expect(last_response.headers['Content-Encoding']).to eq('gzip')
+    end
+  end
+
+  describe 'with Rack::MiniProfiler before Rack::Deflater' do
+    def app
+      Rack::Builder.new do
+        use Rack::MiniProfiler
+        use Rack::Deflater
+        run lambda { |_env| [200, {'Content-Type' => 'text/html'}, ['<html><body><h1>Hi</h1></body></html>']] }
+      end
+    end
+
+    describe 'with suppress_encoding true' do
+      before { Rack::MiniProfiler.config.suppress_encoding = true }
+
+      it 'should inject script and *not* compress' do
+        do_get
+        expect(last_response.body).to include('/mini-profiler-resources/includes.js')
+        expect(last_response.headers).not_to include('Content-Encoding')
+      end
+
+      include_examples 'should not affect a skipped requests'
+    end
+
+    describe 'with suppress_encoding false' do
+      before { Rack::MiniProfiler.config.suppress_encoding = false }
+
+      it 'should *not* inject script but should compress' do
+        do_get
+        expect(decompressed_response).not_to include('/mini-profiler-resources/includes.js')
+        expect(last_response.headers['Content-Encoding']).to eq('gzip')
+      end
+
+      include_examples 'should not affect a skipped requests'
+    end
+
+  end
+
+  describe 'with Rack::Deflater before Rack::MiniProfiler' do
+
+    def app
+      Rack::Builder.new do
+        use Rack::Deflater
+        use Rack::MiniProfiler
+        run lambda { |_env| [200, {'Content-Type' => 'text/html'}, ['<html><body><h1>Hi</h1></body></html>']] }
+      end
+    end
+
+    describe 'with suppress_encoding true' do
+      before { Rack::MiniProfiler.config.suppress_encoding = true }
+
+      it 'should inject script and compress' do
+        do_get
+        expect(decompressed_response).to include('/mini-profiler-resources/includes.js')
+        expect(last_response.headers['Content-Encoding']).to eq('gzip')
+      end
+
+      include_examples 'should not affect a skipped requests'
+    end
+
+    describe 'with suppress_encoding false' do
+      before { Rack::MiniProfiler.config.suppress_encoding = false }
+
+      it 'should inject script and compress' do
+        do_get
+        expect(decompressed_response).to include('/mini-profiler-resources/includes.js')
+        expect(last_response.headers['Content-Encoding']).to eq('gzip')
+      end
+
+      include_examples 'should not affect a skipped requests'
+    end
+  end
+
+end


### PR DESCRIPTION
The middleware ordering when `Rack::Deflater` is in use still seems to be causing issues for a lot of people #70. And Rails 5 introduces a new difficulty in changing the stack order #242.

This PR works around the problem by simply disabling compression on profiled requests. This is a similar approach to disabling caching. Only profiled requests would have compression disabled.

With this approach, all of the configuration hoops around re-ordering the middleware could be removed and it should (hopefully) enable more people to use the automatic initialization. It would also be possible to add another configuration option like `config.disable_compression` just like the existing `config.disable_caching`.

Let me know what you think of this approach and/or if it should be a config setting. If it is a go, I can update the readme and changelog.

BTW, it would be possible in the railtie to use an initializer that runs *after* the stack has been created to decide whether to disable compression.
```ruby
initializer "rack_mini_profiler.after_build_middleware", :after => :build_middleware_stack do |app|
  middlewares = app.middleware.middlewares
  if middlewares.include?(Rack::Deflater) && middlewares.index(Rack::Deflater) > middlewares.index(Rack::MiniProfiler)
    Rack::MiniProfiler.config.disable_compression = true
  end
end
```