### PR TITLE
Move middleware ordering detection to after_initialize block

### DIFF
--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -90,7 +90,7 @@ module Rack::MiniProfilerRails
 
     # Suppress compression when Rack::Deflater is lower in the middleware
     # stack than Rack::MiniProfiler
-    initializer "rack_mini_profiler.after_build_middleware", :after => :build_middleware_stack do |app|
+    config.after_initialize do |app|
       middlewares = app.middleware.middlewares
       if Rack::MiniProfiler.config.suppress_encoding.nil? &&
           middlewares.include?(Rack::Deflater) &&


### PR DESCRIPTION
This resolves the issue with #258 that is causing `:build_middleware_stack` to be executed before all middleware has been configured.

Using an initializer with `:after => :build_middleware_stack` causes the :build_middleware_stack initializer to be pulled forward in the initializer ordering rather than pushing the rack-mini-profiler initializer to execute later. Doing this in as an `after_initialize` ensures it happens later in the process.