### PR TITLE
Improve trace-exceptions output and allow for filtering

### DIFF
--- a/spec/integration/trace_exceptions_spec.rb
+++ b/spec/integration/trace_exceptions_spec.rb
@@ -1,0 +1,84 @@
+# Note: This test is highly dependent on line numbers for backtrace details
+# Take care when changing the structure of this file and update tests accordingly
+
+require 'spec_helper'
+require 'rack-mini-profiler'
+require 'rack/test'
+
+describe 'Rack::MiniProfiler - trace_exceptions', :unless => (RUBY_VERSION < '2.0') do
+  include Rack::Test::Methods
+
+  before(:each) { Rack::MiniProfiler.reset_config }
+
+  def app
+    @app ||= Rack::Builder.new {
+      use Rack::MiniProfiler
+      map '/no_exceptions' do
+        run lambda { |_env| [200, {'Content-Type' => 'text/html'}, '<h1>Success</h1>'] }
+      end
+      map '/raise_exceptions' do
+        # This route raises 3 exceptions, catches them, and returns a successful response
+        run lambda { |_env|
+          begin
+            raise 'Test RuntimeError Exception'
+          rescue
+            # Ignore the exception
+          end
+          begin
+            raise NameError, 'Test NameError Exception'
+          rescue
+            # Ignore the exception
+          end
+          begin
+            raise NoMethodError, 'Test NoMethodError Exception'
+          rescue
+            # Ignore the exception
+          end
+          [200, {'Content-Type' => 'text/html'}, '<h1>Exception raised but success returned</h1>']
+        }
+      end
+    }.to_app
+  end
+
+  it 'with no exceptions' do
+    get '/no_exceptions', :pp => 'trace-exceptions'
+    expect(last_response.body).to include('No exceptions')
+  end
+
+  describe 'with exceptions' do
+    it 'unfiltered' do
+      get '/raise_exceptions', :pp => 'trace-exceptions'
+      expect(last_response.body).to include('Exceptions: (3 total)')
+      expect(last_response.body).to include('RuntimeError - "Test RuntimeError Exception"')
+      expect(last_response.body).to include('NameError - "Test NameError Exception"')
+      expect(last_response.body).to include('NoMethodError - "Test NoMethodError Exception"')
+      expect(last_response.body).to include("  #{__FILE__}:23")
+      expect(last_response.body).to include("  #{__FILE__}:28")
+      expect(last_response.body).to include("  #{__FILE__}:33")
+    end
+
+    it 'with a single filtered exception' do
+      get '/raise_exceptions', :pp => 'trace-exceptions', 'trace_exceptions_filter' => 'RuntimeError'
+      expect(last_response.body).to include('Exceptions: (2 total)')
+      expect(last_response.body).not_to include('RuntimeError - "Test RuntimeError Exception"')
+      expect(last_response.body).to include('NameError - "Test NameError Exception"')
+      expect(last_response.body).to include('NoMethodError - "Test NoMethodError Exception"')
+      expect(last_response.body).not_to include("  #{__FILE__}:23")
+      expect(last_response.body).to include("  #{__FILE__}:28")
+      expect(last_response.body).to include("  #{__FILE__}:33")
+    end
+
+    it 'with a multiple filtered exceptions' do
+      get '/raise_exceptions', :pp => 'trace-exceptions', 'trace_exceptions_filter' => 'NameError|NoMethodError'
+      expect(last_response.body).to include('Exceptions: (1 total)')
+      expect(last_response.body).to include('RuntimeError - "Test RuntimeError Exception"')
+      expect(last_response.body).not_to include('NameError - "Test NameError Exception"')
+      expect(last_response.body).not_to include('NoMethodError - "Test NoMethodError Exception"')
+      expect(last_response.body).to include("  #{__FILE__}:23")
+      expect(last_response.body).not_to include("  #{__FILE__}:28")
+      expect(last_response.body).not_to include("  #{__FILE__}:33")
+    end
+
+  end
+
+end


### PR DESCRIPTION
This PR helps make the output of `pp=trace-exeptions` more readable and allows for the filtering of exceptions by class name. Filtering is done with a `trace_exceptions_filter` query param which is converted to a regex to match against class names the same way `memory_profiler_ignore_files` works with filenames.

The specific case I wanted the filter for was to ignore internal IO exceptions caused by fetching from Redis.

Before
```
Exceptions (64 raised during request)

IO::EAGAINWaitReadable Resource temporarily unavailable - read would block
/Users/dgynn/.rvm/gems/ruby-2.2.5/gems/redis-3.3.1/lib/redis/connection/ruby.rb:79:in `read_nonblock'
/Users/dgynn/.rvm/gems/ruby-2.2.5/gems/redis-3.3.1/lib/redis/connection/ruby.rb:79:in `_read_from_socket'
/Users/dgynn/.rvm/gems/ruby-2.2.5/gems/redis-3.3.1/lib/redis/connection/ruby.rb:70:in `gets'
...
```

After
```
Exceptions raised during request

Exceptions: (64 total)
  IO::EAGAINWaitReadable (55)
  NoMethodError (7)
  ArgumentError (2)

Backtraces
#1: IO::EAGAINWaitReadable - "Resource temporarily unavailable - read would block"
  /Users/dgynn/.rvm/gems/ruby-2.2.5/gems/redis-3.3.1/lib/redis/connection/ruby.rb:79:in `read_nonblock'
  /Users/dgynn/.rvm/gems/ruby-2.2.5/gems/redis-3.3.1/lib/redis/connection/ruby.rb:79:in `_read_from_socket'
  /Users/dgynn/.rvm/gems/ruby-2.2.5/gems/redis-3.3.1/lib/redis/connection/ruby.rb:70:in `gets'
...
```

After with filtering using `?pp=trace-exceptions&trace_exceptions_filter=IO::EAGAINWaitReadable`
```
Exceptions raised during request

Exceptions: (9 total)
  NoMethodError (7)
  ArgumentError (2)

Backtraces
#1: NoMethodError - "undefined method `host_name' for #<User:0x007feaface8578>"
  /Users/dgynn/.rvm/gems/ruby-2.2.5/gems/activemodel-4.0.13/lib/active_model/attribute_methods.rb:439:in `method_missing'
  /Users/dgynn/.rvm/gems/ruby-2.2.5/gems/activerecord-4.0.13/lib/active_record/attribute_methods.rb:168:in `method_missing'
...
```


