### PR TITLE
Updates to new turbolinks event name `turbolinks:load`

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -404,7 +404,7 @@ var MiniProfiler = (function () {
         });
 
         if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
-            $(document).bind('turbolinks:load.mini-profiler', function() {
+            $(document).bind('page:change.mini-profiler turbolinks:load.mini-profiler', function() {
                unbindDocumentEvents();
             });
         }

--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -404,7 +404,7 @@ var MiniProfiler = (function () {
         });
 
         if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
-            $(document).bind('page:change.mini-profiler', function() {
+            $(document).bind('turbolinks:load.mini-profiler', function() {
                unbindDocumentEvents();
             });
         }


### PR DESCRIPTION
Perhaps this should bind to both page:change and turbolinks:load to support backwards compatibility?