### PR TITLE
Avoid some unwanted warnings

### DIFF
--- a/lib/patches/db/mysql2.rb
+++ b/lib/patches/db/mysql2.rb
@@ -3,7 +3,7 @@
 class Mysql2::Result
   alias_method :each_without_profiling, :each
   def each(*args, &blk)
-    return each_without_profiling(*args, &blk) unless @miniprofiler_sql_id
+    return each_without_profiling(*args, &blk) unless defined?(@miniprofiler_sql_id)
 
     start        = Time.now
     result       = each_without_profiling(*args,&blk)

--- a/lib/patches/db/oracle_enhanced.rb
+++ b/lib/patches/db/oracle_enhanced.rb
@@ -1,7 +1,7 @@
 class ActiveRecord::Result
   alias_method :each_without_profiling, :each
   def each(&blk)
-    return each_without_profiling(&blk) unless @miniprofiler_sql_id
+    return each_without_profiling(&blk) unless defined?(@miniprofiler_sql_id)
 
     start        = Time.now
     result       = each_without_profiling(&blk)

--- a/lib/patches/db/pg.rb
+++ b/lib/patches/db/pg.rb
@@ -4,14 +4,14 @@ class PG::Result
   alias_method :values_without_profiling, :values
 
   def values(*args, &blk)
-    return values_without_profiling(*args, &blk) unless @miniprofiler_sql_id
+    return values_without_profiling(*args, &blk) unless defined?(@miniprofiler_sql_id)
     mp_report_sql do
       values_without_profiling(*args ,&blk)
     end
   end
 
   def each(*args, &blk)
-    return each_without_profiling(*args, &blk) unless @miniprofiler_sql_id
+    return each_without_profiling(*args, &blk) unless defined?(@miniprofiler_sql_id)
     mp_report_sql do
       each_without_profiling(*args, &blk)
     end

--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rack', '>= 1.2.0'
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '< 11'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'activerecord', '~> 3.0'
   s.add_development_dependency 'dalli'


### PR DESCRIPTION
Hi,

While reviewing a verbose version of some RSpec logs for a Rails app, I noticed mini profiler generates a lot of warnings that can be avoided pretty simply.