### PR TITLE
Adding sql bindings for pg in profiler results

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -990,7 +990,16 @@ var MiniProfiler = (function () {
         fetchResultsExposed: function (ids) {
             return fetchResults(ids);
         },
-
+        
+        formatParameters: function (parameters) {
+            if (parameters != null) {
+                return parameters.map(function(item, index){ return "["+item[0]+", "+ item[1] +"]";}).join(', ');           
+            }
+            else {
+                return ''; 
+            }
+        },
+        
         formatDuration: function (duration) {
             return (duration || 0).toFixed(1);
         }

--- a/lib/html/includes.tmpl
+++ b/lib/html/includes.tmpl
@@ -202,7 +202,7 @@
     <td>
       <div class="query">
         <pre class="profiler-stack-trace">${s.stack_trace_snippet}</pre>
-        <pre class="prettyprint lang-sql"><code>${s.formatted_command_string}   </code></pre>
+        <pre class="prettyprint lang-sql"><code>${s.formatted_command_string}; ${MiniProfiler.formatParameters(s.parameters)}</code></pre>
       </div>
     </td>
   </tr>

--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -56,15 +56,18 @@ module Rack
         def trim_binds(binds)
           max_len = Rack::MiniProfiler.config.max_sql_param_length
           return if binds.nil? || max_len == 0
-          return binds if max_len.nil?
+          return binds.map{|(name, val)| [name, val]} if max_len.nil?
           binds.map do |(name, val)|
             val ||= name
             if val.nil? || val == true || val == false || val.kind_of?(Numeric)
               # keep these parameters as is
             elsif val.kind_of?(String)
-              val = val[0...max_len] if max_len
+              val = val[0...max_len]+(max_len < val.length ? '...' : '') if max_len
             else
               val = val.class.name
+            end
+            if name.kind_of?(String)
+              name = name[0...max_len]+(max_len < name.length ? '...' : '') if max_len
             end
             [name, val]
           end

--- a/lib/patches/db/pg.rb
+++ b/lib/patches/db/pg.rb
@@ -52,7 +52,7 @@ class PG::Connection
     start        = Time.now
     result       = exec_without_profiling(*args,&blk)
     elapsed_time = SqlPatches.elapsed_time(start)
-    record       = ::Rack::MiniProfiler.record_sql(args[0], elapsed_time)
+    record       = ::Rack::MiniProfiler.record_sql(args[0], elapsed_time, get_binds(*args))
     result.instance_variable_set("@miniprofiler_sql_id", record) if result
 
     result
@@ -66,7 +66,7 @@ class PG::Connection
     elapsed_time = SqlPatches.elapsed_time(start)
     mapped       = args[0]
     mapped       = @prepare_map[mapped] || args[0] if @prepare_map
-    record       = ::Rack::MiniProfiler.record_sql(mapped, elapsed_time)
+    record       = ::Rack::MiniProfiler.record_sql(mapped, elapsed_time, get_binds(mapped, args[1]))
     result.instance_variable_set("@miniprofiler_sql_id", record) if result
 
     result
@@ -80,7 +80,7 @@ class PG::Connection
     elapsed_time = SqlPatches.elapsed_time(start)
     mapped       = args[0]
     mapped       = @prepare_map[mapped] || args[0] if @prepare_map
-    record       = ::Rack::MiniProfiler.record_sql(mapped, elapsed_time)
+    record       = ::Rack::MiniProfiler.record_sql(mapped, elapsed_time, get_binds(mapped, args[1]))
     result.instance_variable_set("@miniprofiler_sql_id", record) if result
 
     result
@@ -92,11 +92,29 @@ class PG::Connection
     start        = Time.now
     result       = exec_without_profiling(*args,&blk)
     elapsed_time = SqlPatches.elapsed_time(start)
-    record       = ::Rack::MiniProfiler.record_sql(args[0], elapsed_time)
+    record       = ::Rack::MiniProfiler.record_sql(args[0], elapsed_time, get_binds(*args))
     result.instance_variable_set("@miniprofiler_sql_id", record) if result
 
     result
   end
-
+  
+  def get_binds(*args)
+    return if args[1].nil?
+    hh = {}
+    if args[0].match(/\(\$\d/) then
+      arr = args[0].match(/\((\"\w+\",?\s?)+\)/).to_s.gsub!(/[",()]/, '').split #regular selects list of names from sql query, for ex. ("name1", "name2", "name3")
+    end   
+    args[1].each_index do |i|
+      if arr then
+        hh[arr[i]]=args[1][i]
+      else
+        var = args[0].match(/[^\s\.]+\s?=?\s\$#{i+1}/).to_s.split[0] #regular selects param name from sql query, like for ex. "name1" = $1
+        var.gsub!(/["]/, '') if var
+        hh[var]=args[1][i]
+      end
+    end
+    return hh
+  end
+  
   alias_method :query, :exec
 end

--- a/spec/lib/timer_struct/sql_timer_struct_spec.rb
+++ b/spec/lib/timer_struct/sql_timer_struct_spec.rb
@@ -95,7 +95,7 @@ describe Rack::MiniProfiler::TimerStruct::Sql do
     it "truncates string parameters" do
       Rack::MiniProfiler.config.max_sql_param_length = 6
       sql = sql_with_params(sample_params)
-      sql[:parameters].should eq [["name", "admin"], ["value", "string"], ["limit", 1]]
+      sql[:parameters].should eq [["name", "admin"], ["value", "string..."], ["limit", 1]]
     end
 
     def sql_with_params(params)


### PR DESCRIPTION
Hi,
according to https://github.com/MiniProfiler/rack-mini-profiler/issues/288 , I added frontend to show it. Also, there was no transfer bindings, and bindings had only value and no name, in pg at least.