### PR TITLE
Ensures that `RedisStore#get_unviewed_ids` returns only ids for existing records

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -334,9 +334,9 @@ module Rack
 
 
       begin
+        @storage.save(page_struct)
         # no matter what it is, it should be unviewed, otherwise we will miss POST
         @storage.set_unviewed(page_struct[:user], page_struct[:id])
-        @storage.save(page_struct)
 
         # inject headers, script
         if status >= 200 && status < 300

--- a/spec/lib/storage/redis_store_spec.rb
+++ b/spec/lib/storage/redis_store_spec.rb
@@ -1,23 +1,24 @@
 require 'spec_helper'
 
 describe Rack::MiniProfiler::RedisStore do
+  let(:store) { Rack::MiniProfiler::RedisStore.new(:db=>2) }
+
+  before do
+    store.send(:redis).flushdb
+  end
 
   context 'establishing a connection to something other than the default' do
-    before do
-      @store = Rack::MiniProfiler::RedisStore.new(:db=>2)
-    end
-
     describe "connection" do
       it 'can still store the resulting value' do
         page_struct = Rack::MiniProfiler::TimerStruct::Page.new({})
         page_struct[:id] = "XYZ"
         page_struct[:random] = "random"
-        @store.save(page_struct)
+        store.save(page_struct)
       end
 
       it 'uses the correct db' do
         # redis is private, and possibly should remain so?
-        underlying_client = @store.send(:redis).client
+        underlying_client = store.send(:redis).client
 
         underlying_client.db.should == 2
       end
@@ -38,79 +39,92 @@ describe Rack::MiniProfiler::RedisStore do
   end
 
   context 'page struct' do
-
-    before do
-      @store = Rack::MiniProfiler::RedisStore.new(nil)
-    end
-
     describe 'storage' do
+      let(:page_structs) { [Rack::MiniProfiler::TimerStruct::Page.new({}),
+                            Rack::MiniProfiler::TimerStruct::Page.new({})] }
 
       it 'can store a PageStruct and retrieve it' do
-        page_struct = Rack::MiniProfiler::TimerStruct::Page.new({})
-        page_struct[:id] = "XYZ"
-        page_struct[:random] = "random"
-        @store.save(page_struct)
-        page_struct = @store.load("XYZ")
-        page_struct[:random].should == "random"
-        page_struct[:id].should == "XYZ"
+        page_structs.first[:id] = "XYZ"
+        page_structs.first[:random] = "random"
+        store.save(page_structs.first)
+
+        page_struct = store.load(page_structs.first[:id])
+
+        page_struct[:random].should eq("random")
+        page_struct[:id].should eq("XYZ")
       end
 
       it 'can list unviewed items for a user' do
-        @store.set_unviewed('a', 'XYZ')
-        @store.set_unviewed('a', 'ABC')
-        @store.get_unviewed_ids('a').should =~ ['XYZ', 'ABC']
+        page_structs.each do |page_struct|
+          store.set_unviewed('a', page_struct[:id])
+          store.save(page_struct)
+        end
+
+        store.get_unviewed_ids('a').should =~ page_structs.map { |page_struct| page_struct[:id] }
       end
 
       it 'can set all unviewed items for a user' do
-        @store.set_unviewed('a', 'XYZ')
-        @store.set_unviewed('a', 'ABC')
-        @store.set_all_unviewed('a', %w(111 222))
-        @store.get_unviewed_ids('a').should == ['111', '222']
-        @store.set_all_unviewed('a', [])
+        page_structs.each { |page_struct| store.save(page_struct) }
+        store.get_unviewed_ids('a').should be_empty
+
+        store.set_all_unviewed('a', page_structs.map { |page_struct| page_struct[:id] })
+
+        store.get_unviewed_ids('a').should =~ page_structs.map { |page_struct| page_struct[:id] }
       end
 
       it 'can set an item to viewed once it is unviewed' do
-        @store.set_unviewed('a', 'XYZ')
-        @store.set_unviewed('a', 'ABC')
-        @store.set_viewed('a', 'XYZ')
-        @store.get_unviewed_ids('a').should == ['ABC']
+        page_structs.each do |page_struct|
+          store.set_unviewed('a', page_struct[:id])
+          store.save(page_struct)
+        end
+
+        store.set_viewed('a', page_structs.first[:id])
+        store.get_unviewed_ids('a').should =~ page_structs.drop(1).map{ |page_struct| page_struct[:id] }
       end
-
     end
+  end
 
+  describe '#get_unviewed_ids' do
+    let(:expired_record_key) { 'xyz098' }
+    let(:existing_struct) { Rack::MiniProfiler::TimerStruct::Page.new({}) }
+
+    it 'should only return ids for keys that exist' do
+      user = 1234
+      expired_record_id = 'xyz098'
+
+      # Simulate a valid record
+      store.set_unviewed(user, existing_struct[:id])
+      store.save(existing_struct)
+
+      # Simluate a record that may have expired, but could remain in the list of ids
+      store.set_unviewed(user, expired_record_id)
+
+      # Only the PageStruct that still exists should be returned
+      store.get_unviewed_ids(user).should eq([existing_struct[:id]])
+    end
   end
 
   describe 'allowed_tokens' do
-    before do
-      @store = Rack::MiniProfiler::RedisStore.new(:db=>2)
-    end
-
     it 'should return tokens' do
+      store.flush_tokens
 
-      @store.flush_tokens
-
-      tokens = @store.allowed_tokens
+      tokens = store.allowed_tokens
       tokens.length.should == 1
 
-      @store.simulate_expire
+      store.simulate_expire
 
-      new_tokens = @store.allowed_tokens
+      new_tokens = store.allowed_tokens
 
       new_tokens.length.should == 2
       (new_tokens - tokens).length.should == 1
     end
   end
 
-
   describe 'diagnostics' do
-    before do
-      @store = Rack::MiniProfiler::RedisStore.new(:db=>2)
-    end
     it "returns useful info" do
-      res = @store.diagnostics('a')
+      res = store.diagnostics('a')
       expected = "Redis prefix: MPRedisStore\nRedis location: 127.0.0.1:6379 db: 2\nunviewed_ids: []\n"
       expect(res).to eq(expected)
     end
   end
-
 end


### PR DESCRIPTION
When using rack-mini-profiler configured with `RedisStore`, I began encountering 404 responses when `includes.js` made POST requests to `/mini-profiler-resources/results` after 24 hours of use. These 404 errors were due to the store being unable to load records matching the ids sent by the client because they had expired. The client receives these ids via the `X-MiniProfiler-Ids` header, which is provided by `RedisStore#get_unviewed_ids`.

`RedisStore#get_unviewed_ids` had the possibility of containing references to redis records that were expired. This is because the list of unviewed ids and the individual `PageStruct` records could become out of sync; individual records have their expiration set once when initially saved, but the list of unviewed ids has its expiration renewed every time a record is added to the list. The result is that the records would expire, but the list would continue to reference those records.

To ensure that `RedisStore#get_unviewed_ids` only returns ids with matching existing records, it now iterates through the list of unviewed ids and removes members that do not exist.

A test has been added to `redis_store_spec.rb` to expose this issue. Additional cleanup work has been performed in this spec; notably, the store db is now flushed prior to each spec. This revealed some broken tests that I've attempted to clean up and fix.