### PR TITLE
SQL query matcher should work on "<model>.<attr>".

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'http://rubygems.org'
 gemspec
 
 gem 'codecov', :require => false, :group => :test
+gem 'pg'
 
 if RUBY_VERSION < '2.0.0'
   gem 'json', '~>1.8'

--- a/lib/patches/db/pg.rb
+++ b/lib/patches/db/pg.rb
@@ -108,7 +108,7 @@ class PG::Connection
     arr = nil
 
     if sql.match(/\(\$\d/)
-      arr = sql.match(/\((\"\w+\",?\s?)+\)/).to_s.gsub!(/[",()]/, '').split #regular selects list of names from sql query, for ex. ("name1", "name2", "name3")
+      arr = sql.match(/\((\"\w+\",?[\s\.]?)+\)/).to_s.gsub!(/[",()]/, '').split #regular selects list of names from sql query, for ex. ("name1", "name2", "name3")
     end
 
     params.each_index do |i|

--- a/spec/lib/patches/db/pg_spec.rb
+++ b/spec/lib/patches/db/pg_spec.rb
@@ -1,0 +1,21 @@
+require 'pg'
+
+require './lib/patches/db/pg'
+
+require 'spec_helper'
+
+describe PG::Connection do
+  let(:conn) { described_class.open(dbname: 'test') }
+
+  describe '.get_binds' do
+    let(:params) { ['id', 'name'] }
+
+    let(:sql) { 'SELECT  1 AS one FROM "my_model" WHERE LOWER("my_model"."name") = LOWER($1) AND ("my_model"."id" != $2) LIMIT $3' }
+
+    let(:args) { [sql, params] }
+
+    it 'should work' do
+      expect { conn.get_binds(args) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
The following query broke the code inside the `match`:

```
SELECT  1 AS one FROM "my_model" WHERE LOWER("my_model"."name") = LOWER($1) AND ("my_model"."id" != $2) LIMIT $3
```

When tracing the execution, it seems to me that the regex inside `match` should
match the combination of `model_name` and `attribute_name`, which was fixed by
adding the dot to the whitespace at the end of the regex.

---

I couldn't find the specs for this, nor I'm sure about the long-term consequences of this change, but I'd be happy to work with the maintainers to solve both issues.