### PR TITLE
Freeze some trivial common strings

### DIFF
--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Rack
   class MiniProfiler
 
@@ -9,7 +10,7 @@ module Rack
           stack_trace = nil
           unless skip_backtrace || duration_ms < Rack::MiniProfiler.config.backtrace_threshold_ms
             # Allow us to filter the stack trace
-            stack_trace = ""
+            stack_trace = "".dup
              # Clean up the stack trace if there are options to do so
             Kernel.caller.each do |ln|
               ln.gsub!(Rack::MiniProfiler.config.backtrace_remove, '') if Rack::MiniProfiler.config.backtrace_remove and !full_backtrace

--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -10,7 +10,7 @@ module Rack
           stack_trace = nil
           unless skip_backtrace || duration_ms < Rack::MiniProfiler.config.backtrace_threshold_ms
             # Allow us to filter the stack trace
-            stack_trace = "".dup
+            stack_trace = String.new
              # Clean up the stack trace if there are options to do so
             Kernel.caller.each do |ln|
               ln.gsub!(Rack::MiniProfiler.config.backtrace_remove, '') if Rack::MiniProfiler.config.backtrace_remove and !full_backtrace


### PR DESCRIPTION
Making sure these are frozen saved around half a million allocations per
request in a large app.