### PR TITLE
Add "X-MiniProfiler-Original-Cache-Control" to store original Cache-Control

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -366,6 +366,7 @@ module Rack
         headers.delete('Date')
       end
 
+      headers['X-MiniProfiler-Original-Cache-Control'] = headers['Cache-Control']
       headers['Cache-Control'] = "#{"no-store, " if config.disable_caching}must-revalidate, private, max-age=0"
 
       # inject header

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -20,7 +20,7 @@ describe Rack::MiniProfiler do
           if ims.size > 0
             [304, {'Content-Type' => 'application/json'}, '']
           else
-            [200, {'Content-Type' => 'application/json'}, '{"name": "Ryan"}']
+            [200, {'Content-Type' => 'application/json', 'Cache-Control' => 'original-cache-control'}, '{"name": "Ryan"}']
           end
         }
       end
@@ -191,6 +191,7 @@ describe Rack::MiniProfiler do
   describe 'configuration' do
     it "should remove caching headers by default" do
       get '/cached-resource'
+      last_response.headers['X-MiniProfiler-Original-Cache-Control'].should == 'original-cache-control'
       last_response.headers['Cache-Control'].should include('no-store')
     end
 
@@ -214,6 +215,7 @@ describe Rack::MiniProfiler do
 
       it "should be able to re-enable caching" do
         get '/cached-resource'
+        last_response.headers['X-MiniProfiler-Original-Cache-Control'].should == 'original-cache-control'
         last_response.headers['Cache-Control'].should_not include('no-store')
       end
     end


### PR DESCRIPTION
Make store original "Cache-Control" of header.

Because I'm using CDN and need to change "Cache-Control" header, it is important to know the real header in production