### PR TITLE
InstallGenerator for Rails application

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,10 @@ gem 'rack-mini-profiler', require: false
 Note the `require: false` part - if omitted, it will cause the Railtie for the mini-profiler to
 be loaded outright, and an attempt to re-initialize it manually will raise an exception.
 
-Then put initialize code in file like `config/initializers/rack_profiler.rb`
+Then run the generator which will set up rack-mini-profiler in development:
 
-```ruby
-if Rails.env == 'development'
-  require 'rack-mini-profiler'
-
-  # initialization is skipped so trigger it
-  Rack::MiniProfilerRails.initialize!(Rails.application)
-end
+```bash
+bundle exec rails g rack_profiler:install
 ```
 
 #### Rack Builder

--- a/lib/generators/rack_profiler/USAGE
+++ b/lib/generators/rack_profiler/USAGE
@@ -1,0 +1,2 @@
+description:
+    Enable rack-mini-profiler in development for your application.

--- a/lib/generators/rack_profiler/install_generator.rb
+++ b/lib/generators/rack_profiler/install_generator.rb
@@ -1,0 +1,11 @@
+module RackProfiler
+  module Generators
+    class InstallGenerator < ::Rails::Generators::Base
+      source_root File.expand_path("templates", __dir__)
+
+      def create_initializer_file
+        copy_file "rack_profiler.rb", "config/initializers/rack_profiler.rb"
+      end
+    end
+  end
+end

--- a/lib/generators/rack_profiler/templates/rack_profiler.rb
+++ b/lib/generators/rack_profiler/templates/rack_profiler.rb
@@ -1,0 +1,6 @@
+if Rails.env.development?
+  require "rack-mini-profiler"
+
+  # initialization is skipped so trigger it
+  Rack::MiniProfilerRails.initialize!(Rails.application)
+end


### PR DESCRIPTION
I've implemented RackProfiler::Generators::InstallGenerator to be easy to set up rack-mini-profiler  for Rails application:

```bash
$ bin/rails g rack_profiler:install
```

- The filename of initializers is named not `rack-mini-profiler.rb` but `rack_profile.rb`. Becase filename is expected to be not kebab-case but snake-case.
- Updated README
