### PR TITLE
Fix toggle shortcut doesn't work

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -400,7 +400,7 @@ var MiniProfiler = (function () {
                 popupHide(button, popup);
             }
         });
-        $(document).on('keydown.mini-profiler', options.toggleShortcut, function(e) {
+        $(document).on('keydown.mini-profiler', null, options.toggleShortcut, function(e) {
             $('.profiler-results').toggle();
         });
 


### PR DESCRIPTION
Hello. 
Toggle shortcut doesn't work on `v0.10.5`.

Keydown event for the shorcut isn't added due to wrong syntax.
Second argument `null` is required. (refs: [README](https://github.com/jeresig/jquery.hotkeys/blob/0d75b7907961d9f60ad1e3bb82f146cc7a3a8996/README.md#jqueryhotkeys-) )