### PR TITLE
Fix reference to CacheCleanupThread in MemoryStore

### DIFF
--- a/lib/mini_profiler/storage/memory_store.rb
+++ b/lib/mini_profiler/storage/memory_store.rb
@@ -70,7 +70,7 @@ module Rack
         cleanup_cycle    = args.fetch(:cleanup_cycle)    { CLEANUP_CYCLE }
         t = CacheCleanupThread.new(cleanup_interval, cleanup_cycle, self) do |t|
           until Thread.current[:should_exit] do
-            self.sleepy_run
+            CacheCleanupThread.current.sleepy_run
           end
         end
         at_exit { t[:should_exit] = true }


### PR DESCRIPTION
Had the problem:
`~/.rvm/gems/ruby-2.3.1/gems/rack-mini-profiler-0.10.5/lib/mini_profiler/storage/memory_store.rb:73:in 'block in initialize_cleanup_thread': undefined method 'sleepy_run' for #<Rack::MiniProfiler::MemoryStore:0x000000071b97c8> (NoMethodError)`

Using:
bundler 1.15.4
ruby 2.3.1
rails 4.2.6
rack 1.6.4
rack-timeout 0.4.2
rack-test 0.6.3
rack-handlers 0.7.3
rack-mini-profiler 0.10.5
rack-protection 1.5.3
rack-contrib 1.4.0