### PR TITLE
Record query plan for postgres SELECT statements.

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -53,12 +53,14 @@ var MiniProfiler = (function () {
         var key = 'templates',
             cached = load(key);
 
-        if (cached) {
+        //if (cached) {
+        if (false) {
             $('body').append(cached);
             success();
         }
         else {
-            $.get(options.path + 'includes.tmpl?v=' + options.version, function (data) {
+            //$.get(options.path + 'includes.tmpl?v=' + options.version, function (data) {
+            $.get(options.path + 'includes.tmpl', function (data) {
                 if (data) {
                     save(key, data);
                     $('body').append(data);

--- a/lib/html/includes.tmpl
+++ b/lib/html/includes.tmpl
@@ -203,6 +203,11 @@
       <div class="query">
         <pre class="profiler-stack-trace">${s.stack_trace_snippet}</pre>
         <pre class="prettyprint lang-sql"><code>${s.formatted_command_string}; ${MiniProfiler.formatParameters(s.parameters)}</code></pre>
+        <br />
+        Query plan, if PG:
+        <br />
+        <br />
+        <pre class="prettyprint lang-sql"><code>${s.explain_output}</code></pre>
       </div>
     </td>
   </tr>

--- a/lib/mini_profiler/profiling_methods.rb
+++ b/lib/mini_profiler/profiling_methods.rb
@@ -2,10 +2,10 @@ module Rack
   class MiniProfiler
     module ProfilingMethods
 
-      def record_sql(query, elapsed_ms, params = nil)
+      def record_sql(query, elapsed_ms, explain_output = nil, params = nil)
         return unless current && current.current_timer
         c = current
-        c.current_timer.add_sql(query, elapsed_ms, c.page_struct, params, c.skip_backtrace, c.full_backtrace)
+        c.current_timer.add_sql(query, elapsed_ms, c.page_struct, explain_output, params, c.skip_backtrace, c.full_backtrace)
       end
 
       def start_step(name)

--- a/lib/mini_profiler/timer_struct/request.rb
+++ b/lib/mini_profiler/timer_struct/request.rb
@@ -89,8 +89,8 @@ module Rack
           end
         end
 
-        def add_sql(query, elapsed_ms, page, params = nil, skip_backtrace = false, full_backtrace = false)
-          TimerStruct::Sql.new(query, elapsed_ms, page, self, params, skip_backtrace, full_backtrace).tap do |timer|
+        def add_sql(query, elapsed_ms, page, explain_output = nil, params = nil, skip_backtrace = false, full_backtrace = false)
+          TimerStruct::Sql.new(query, elapsed_ms, page, self, explain_output, params, skip_backtrace, full_backtrace).tap do |timer|
             self[:sql_timings].push(timer)
             timer[:parent_timing_id] = self[:id]
             self[:has_sql_timings]   = true

--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -5,7 +5,7 @@ module Rack
     # Timing system for a SQL query
     module TimerStruct
       class Sql < TimerStruct::Base
-        def initialize(query, duration_ms, page, parent, params = nil, skip_backtrace = false, full_backtrace = false)
+        def initialize(query, duration_ms, page, parent, explain_output = nil, params = nil, skip_backtrace = false, full_backtrace = false)
 
           stack_trace = nil
           unless skip_backtrace || duration_ms < Rack::MiniProfiler.config.backtrace_threshold_ms
@@ -42,7 +42,8 @@ module Rack
             :first_fetch_duration_milliseconds => duration_ms,
             :parameters                        => trim_binds(params),
             :parent_timing_id                  => nil,
-            :is_duplicate                      => false
+            :is_duplicate                      => false,
+            :explain_output                    => explain_output.to_s
           )
         end
 

--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -8,7 +8,7 @@ class SqlPatches
   def self.record_sql(statement, parameters = nil, &block)
     start  = Time.now
     result = yield
-    record = ::Rack::MiniProfiler.record_sql(statement, elapsed_time(start), parameters)
+    record = ::Rack::MiniProfiler.record_sql(statement, elapsed_time(start), nil, parameters)
     return result, record
   end
 

--- a/spec/lib/timer_struct/sql_timer_struct_spec.rb
+++ b/spec/lib/timer_struct/sql_timer_struct_spec.rb
@@ -13,7 +13,7 @@ describe Rack::MiniProfiler::TimerStruct::Sql do
 
     [
       :execute_type, :formatted_command_string, :stack_trace_snippet, :start_milliseconds, :duration_milliseconds,
-      :first_fetch_duration_milliseconds, :is_duplicate
+      :first_fetch_duration_milliseconds, :is_duplicate, :explain_output
     ].each do |attr_type|
       it "has an #{attr_type}" do
         @sql[attr_type].should_not be_nil


### PR DESCRIPTION
Seeing the query plan generated by EXPLAIN SELECT is useful for my current project. Here it's recorded only by the PG patch; it could be implemented in other patches as well.

NOTE: getting this ready to be considered for actual merge will be a longer-term project.