### PR TITLE
Fix error with webrick and empty cache control

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -366,7 +366,7 @@ module Rack
         headers.delete('Date')
       end
 
-      headers['X-MiniProfiler-Original-Cache-Control'] = headers['Cache-Control']
+      headers['X-MiniProfiler-Original-Cache-Control'] = headers['Cache-Control'] unless headers['Cache-Control'].nil?
       headers['Cache-Control'] = "#{"no-store, " if config.disable_caching}must-revalidate, private, max-age=0"
 
       # inject header

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -195,6 +195,11 @@ describe Rack::MiniProfiler do
       last_response.headers['Cache-Control'].should include('no-store')
     end
 
+    it "should not store the original cache header if not set" do
+      get '/html'
+      last_response.headers.should_not have_key('X-MiniProfiler-Original-Cache-Control')
+    end
+
     it "should strip if-modified-since on the way in" do
       old_time = 1409326086
       get '/cached-resource', {}, {'HTTP_IF_MODIFIED_SINCE' => old_time}


### PR DESCRIPTION
Webrick assumes each header key has a value. Don't store the
old Cache-Control value unless it existed.

The error caused by Webrick is the same as the one detailed here: https://mensfeld.pl/2013/01/ruby-on-rails-webrick-error-nomethoderror-undefined-method-split-for-nilnilclass/