### PR TITLE
Add source code and changelog links to gemspec

### DIFF
--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -21,6 +21,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rack', '>= 1.2.0'
   s.required_ruby_version = '>= 1.9.3'
 
+  s.metadata = {
+    'source_code_uri' => 'https://github.com/MiniProfiler/rack-mini-profiler',
+    'changelog_uri'   => 'https://github.com/MiniProfiler/rack-mini-profiler/blob/master/CHANGELOG.md'
+  }
+
   s.add_development_dependency 'rake', '< 11'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'activerecord', '~> 3.0'


### PR DESCRIPTION
Makes it easy to programatically find the source code and changelog for `rack-mini-profiler`, using the rubygems API. More details on the direction of travel for gemspecs is [here](https://github.com/rubygems/rubygems.org/issues/1127) and [here](https://github.com/rubygems/rubygems.org/pull/1234), and the current state is [here](https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb).

(My interest in this is so that [Dependabot](https://dependabot.com) can find a link to the `rack-mini-profiler` source code when it creates PRs.)