### PR TITLE
Replace Time.now with Process.clock_gettime(Process::CLOCK_MONOTONIC) everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Pending
+
+- [FEATURE] Replace Time.now with Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
 ## 0.10.6 2017-10-30
 
 - [FEATURE] Support for vertical positions (top/bottom)

--- a/README.md
+++ b/README.md
@@ -8,12 +8,9 @@ Middleware that displays speed badge for every html page. Designed to work both 
 
 Well, not exactly mega urgent, but nice to see you are reading this.
 
-There are 2 very simple changes I would like to see ASAP
+There is one very simple change I would like to see ASAP: I would like to see `# frozen_string_literal: true` on every file we ship
 
-1. Stop using Time.now EVERYWHERE in rack-mini-profiler and replace with `Process.clock_gettime(Process::CLOCK_MONOTONIC)`
-2. I would like to see `# frozen_string_literal: true` on every file we ship
-
-If you pick up either of these, be sure to amend the README in your PR AND add a Changelog. 
+If you pick up this task, be sure to amend the README in your PR AND add a Changelog. 
 
 #### Features
 

--- a/lib/mini_profiler/client_settings.rb
+++ b/lib/mini_profiler/client_settings.rb
@@ -42,7 +42,7 @@ module Rack
         if (MiniProfiler.config.authorization_mode == :whitelist && !MiniProfiler.request_authorized?)
           # this is non-obvious, don't kill the profiling cookie on errors or short requests
           # this ensures that stuff that never reaches the rails stack does not kill profiling
-          if status.to_i >= 200 && status.to_i < 300 && ((Time.now - @start) > 0.1)
+          if status.to_i >= 200 && status.to_i < 300 && ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - @start) > 0.1)
             discard_cookie!(headers)
           end
         else

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -149,7 +149,7 @@ module Rack
 
     def call(env)
 
-      start = Time.now
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       client_settings = ClientSettings.new(env, @storage, start)
       MiniProfiler.deauthorize_request if @config.authorization_mode == :whitelist
 
@@ -325,7 +325,7 @@ module Rack
 
       page_struct = current.page_struct
       page_struct[:user] = user(env)
-      page_struct[:root].record_time((Time.now - start) * 1000)
+      page_struct[:root].record_time((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000)
 
       if flamegraph
         body.close if body.respond_to? :close

--- a/lib/mini_profiler/profiling_methods.rb
+++ b/lib/mini_profiler/profiling_methods.rb
@@ -89,11 +89,11 @@ module Rack
           parent_timer = Rack::MiniProfiler.current.current_timer
 
           if type == :counter
-            start = Time.now
+            start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
             begin
               self.send without_profiling, *args, &orig
             ensure
-              duration_ms = (Time.now - start).to_f * 1000
+              duration_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start).to_f * 1000
               parent_timer.add_custom(name, duration_ms, Rack::MiniProfiler.current.page_struct )
             end
           else
@@ -131,9 +131,9 @@ module Rack
       def counter(type, duration_ms=nil)
         result = nil
         if block_given?
-          start       = Time.now
+          start       = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           result      = yield
-          duration_ms = (Time.now - start).to_f * 1000
+          duration_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start).to_f * 1000
         end
         return result if current.nil? || !request_authorized?
         current.current_timer.add_custom(type, duration_ms, current.page_struct)

--- a/lib/mini_profiler/storage/file_store.rb
+++ b/lib/mini_profiler/storage/file_store.rb
@@ -139,10 +139,10 @@ module Rack
         @auth_token_lock.synchronize {
           token1, token2, cycle_at = @auth_token_cache[""]
 
-          unless cycle_at && (Time === cycle_at) && (cycle_at > Time.now)
+          unless cycle_at && (Float === cycle_at) && (cycle_at > Process.clock_gettime(Process::CLOCK_MONOTONIC))
             token2 = token1
             token1 = SecureRandom.hex
-            cycle_at = Time.now + Rack::MiniProfiler::AbstractStore::MAX_TOKEN_AGE
+            cycle_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) + Rack::MiniProfiler::AbstractStore::MAX_TOKEN_AGE
           end
 
           @auth_token_cache[""] = [token1, token2, cycle_at]

--- a/lib/mini_profiler/storage/memcache_store.rb
+++ b/lib/mini_profiler/storage/memcache_store.rb
@@ -67,7 +67,7 @@ module Rack
            key1 = nil unless key1 && key1.length == 32
            key2 = nil unless key2 && key2.length == 32
 
-           if key1 && cycle_at && (cycle_at > Time.now)
+           if key1 && cycle_at && (cycle_at > Process.clock_gettime(Process::CLOCK_MONOTONIC))
               return [key1,key2].compact
            end
         end
@@ -77,7 +77,7 @@ module Rack
         # cycle keys
         key2 = key1
         key1 = SecureRandom.hex
-        cycle_at = Time.now + timeout
+        cycle_at = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
 
         @client.set("#{@prefix}-tokens", Marshal::dump([key1, key2, cycle_at]))
 

--- a/lib/mini_profiler/storage/redis_store.rb
+++ b/lib/mini_profiler/storage/redis_store.rb
@@ -32,7 +32,7 @@ module Rack
       def set_unviewed(user, id)
         key = user_key(user)
         if redis.exists(prefixed_id(id))
-          expire_at = Time.now.to_i + redis.ttl(prefixed_id(id))
+          expire_at = Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i + redis.ttl(prefixed_id(id))
           redis.zadd(key, expire_at, id)
         end
         redis.expire(key, @expires_in_seconds)
@@ -43,7 +43,7 @@ module Rack
         redis.del(key)
         ids.each do |id|
           if redis.exists(prefixed_id(id))
-            expire_at = Time.now.to_i + redis.ttl(prefixed_id(id))
+            expire_at = Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i + redis.ttl(prefixed_id(id))
             redis.zadd(key, expire_at, id)
           end
         end
@@ -57,7 +57,7 @@ module Rack
       # Remove expired ids from the unviewed sorted set and return the remaining ids
       def get_unviewed_ids(user)
         key = user_key(user)
-        redis.zremrangebyscore(key, '-inf', Time.now.to_i)
+        redis.zremrangebyscore(key, '-inf', Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i)
         redis.zrevrangebyscore(key, '+inf', '-inf')
       end
 

--- a/lib/mini_profiler/timer_struct/custom.rb
+++ b/lib/mini_profiler/timer_struct/custom.rb
@@ -8,7 +8,7 @@ module Rack
           @parent      = parent
           @page        = page
           @type        = type
-          start_millis = ((Time.now.to_f * 1000).to_i - page[:started]) - duration_ms
+          start_millis = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1000).to_i - page[:started]) - duration_ms
           super(
             :type                  => type,
             :start_milliseconds    => start_millis,

--- a/lib/mini_profiler/timer_struct/page.rb
+++ b/lib/mini_profiler/timer_struct/page.rb
@@ -11,7 +11,7 @@ module Rack
         def initialize(env)
           timer_id     = MiniProfiler.generate_id
           page_name    = env['PATH_INFO']
-          started_at   = (Time.now.to_f * 1000).to_i
+          started_at   = (Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1000).to_i
           machine_name = env['SERVER_NAME']
           super(
             :id                                      => timer_id,

--- a/lib/mini_profiler/timer_struct/request.rb
+++ b/lib/mini_profiler/timer_struct/request.rb
@@ -12,7 +12,7 @@ module Rack
         attr_accessor :children_duration
 
         def initialize(name, page, parent)
-          start_millis = (Time.now.to_f * 1000).to_i - page[:started]
+          start_millis = (Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1000).to_i - page[:started]
           depth        = parent ? parent.depth + 1 : 0
           super(
             :id                                      => MiniProfiler.generate_id,
@@ -39,7 +39,7 @@ module Rack
             :custom_timings                          => {}
           )
           @children_duration = 0
-          @start             = Time.now
+          @start             = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           @parent            = parent
           @page              = page
         end
@@ -117,7 +117,7 @@ module Rack
         end
 
         def record_time(milliseconds = nil)
-          milliseconds ||= (Time.now - @start) * 1000
+          milliseconds ||= (Process.clock_gettime(Process::CLOCK_MONOTONIC) - @start) * 1000
           self[:duration_milliseconds]                  = milliseconds
           self[:is_trivial]                             = true if milliseconds < self[:trivial_duration_threshold_milliseconds]
           self[:duration_without_children_milliseconds] = milliseconds - @children_duration

--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -32,7 +32,7 @@ module Rack
 
           @parent      = parent
           @page        = page
-          start_millis = ((Time.now.to_f * 1000).to_i - page[:started]) - duration_ms
+          start_millis = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1000).to_i - page[:started]) - duration_ms
           super(
             :execute_type                      => 3, # TODO
             :formatted_command_string          => query,

--- a/lib/patches/db/activerecord.rb
+++ b/lib/patches/db/activerecord.rb
@@ -28,7 +28,7 @@ module Rack
         return log_without_miniprofiler(*args, &block) unless SqlPatches.should_measure?
 
         sql, name, binds = args
-        start            = Time.now
+        start            = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         rval             = log_without_miniprofiler(*args, &block)
 
         # Don't log schema queries if the option is set

--- a/lib/patches/db/mysql2.rb
+++ b/lib/patches/db/mysql2.rb
@@ -5,7 +5,7 @@ class Mysql2::Result
   def each(*args, &blk)
     return each_without_profiling(*args, &blk) unless defined?(@miniprofiler_sql_id)
 
-    start        = Time.now
+    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result       = each_without_profiling(*args,&blk)
     elapsed_time = SqlPatches.elapsed_time(start)
 

--- a/lib/patches/db/neo4j.rb
+++ b/lib/patches/db/neo4j.rb
@@ -3,7 +3,7 @@ class Neo4j::Core::Query
 
   def response
     return @response if @response
-    start = Time.now
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     rval = response_without_miniprofiler
     elapsed_time = SqlPatches.elapsed_time(start)
     Rack::MiniProfiler.record_sql(to_cypher, elapsed_time)

--- a/lib/patches/db/oracle_enhanced.rb
+++ b/lib/patches/db/oracle_enhanced.rb
@@ -3,7 +3,7 @@ class ActiveRecord::Result
   def each(&blk)
     return each_without_profiling(&blk) unless defined?(@miniprofiler_sql_id)
 
-    start        = Time.now
+    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result       = each_without_profiling(&blk)
     elapsed_time = SqlPatches.elapsed_time(start)
     @miniprofiler_sql_id.report_reader_duration(elapsed_time)
@@ -45,7 +45,7 @@ class ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter
   def mp_profile_sql(sql, name, &blk)
     return yield unless mp_should_measure?(name)
 
-    start        = Time.now
+    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result       = yield
     elapsed_time = SqlPatches.elapsed_time(start)
     record       = ::Rack::MiniProfiler.record_sql(sql, elapsed_time)

--- a/lib/patches/db/pg.rb
+++ b/lib/patches/db/pg.rb
@@ -18,7 +18,7 @@ class PG::Result
   end
 
   def mp_report_sql(&block)
-    start        = Time.now
+    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result       = yield
     elapsed_time = SqlPatches.elapsed_time(start)
     @miniprofiler_sql_id.report_reader_duration(elapsed_time)
@@ -49,7 +49,7 @@ class PG::Connection
   def exec(*args,&blk)
     return exec_without_profiling(*args,&blk) unless SqlPatches.should_measure?
 
-    start        = Time.now
+    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result       = exec_without_profiling(*args,&blk)
     elapsed_time = SqlPatches.elapsed_time(start)
     record       = ::Rack::MiniProfiler.record_sql(args[0], elapsed_time)
@@ -61,7 +61,7 @@ class PG::Connection
   def exec_prepared(*args,&blk)
     return exec_prepared_without_profiling(*args,&blk) unless SqlPatches.should_measure?
 
-    start        = Time.now
+    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result       = exec_prepared_without_profiling(*args,&blk)
     elapsed_time = SqlPatches.elapsed_time(start)
     mapped       = args[0]
@@ -75,7 +75,7 @@ class PG::Connection
   def send_query_prepared(*args,&blk)
     return send_query_prepared_without_profiling(*args,&blk) unless SqlPatches.should_measure?
 
-    start        = Time.now
+    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result       = send_query_prepared_without_profiling(*args,&blk)
     elapsed_time = SqlPatches.elapsed_time(start)
     mapped       = args[0]
@@ -89,7 +89,7 @@ class PG::Connection
   def async_exec(*args,&blk)
     return async_exec_without_profiling(*args,&blk) unless SqlPatches.should_measure?
 
-    start        = Time.now
+    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result       = exec_without_profiling(*args,&blk)
     elapsed_time = SqlPatches.elapsed_time(start)
     record       = ::Rack::MiniProfiler.record_sql(args[0], elapsed_time)

--- a/lib/patches/db/plucky.rb
+++ b/lib/patches/db/plucky.rb
@@ -27,7 +27,7 @@ class Plucky::Query
   def profile_database_operation(method, message, *args, &blk)
     return self.send("#{method.id2name}_without_profiling", *args, &blk) unless SqlPatches.should_measure?
 
-    start        = Time.now
+    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result       = self.send("#{method.id2name}_without_profiling", *args, &blk)
     elapsed_time = SqlPatches.elapsed_time(start)
 

--- a/lib/patches/db/riak.rb
+++ b/lib/patches/db/riak.rb
@@ -5,7 +5,7 @@ class Riak::Multiget
     def get_all(client, fetch_list)
       return get_all_without_profiling(client, fetch_list) unless SqlPatches.should_measure?
 
-      start        = Time.now
+      start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       result       = get_all_without_profiling(client, fetch_list)
       elapsed_time = SqlPatches.elapsed_time(start)
       record       = ::Rack::MiniProfiler.record_sql("get_all size=#{fetch_list.size}", elapsed_time)
@@ -92,7 +92,7 @@ class Riak::Client
   def profile(request, &blk)
     return yield unless SqlPatches.should_measure?
 
-    start        = Time.now
+    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result       = yield
     elapsed_time = SqlPatches.elapsed_time(start)
     record       = ::Rack::MiniProfiler.record_sql(request, elapsed_time)

--- a/lib/patches/db/rsolr.rb
+++ b/lib/patches/db/rsolr.rb
@@ -3,7 +3,7 @@ class RSolr::Connection
   def execute_with_profiling(client, request_context)
     return execute_without_profiling(client, request_context) unless SqlPatches.should_measure?
 
-    start        = Time.now
+    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result       = execute_without_profiling(client, request_context)
     elapsed_time = SqlPatches.elapsed_time(start)
 

--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -6,7 +6,7 @@ class SqlPatches
   end
 
   def self.record_sql(statement, parameters = nil, &block)
-    start  = Time.now
+    start  = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result = yield
     record = ::Rack::MiniProfiler.record_sql(statement, elapsed_time(start), parameters)
     return result, record
@@ -18,7 +18,7 @@ class SqlPatches
   end
 
   def self.elapsed_time(start_time)
-    ((Time.now - start_time).to_f * 1000).round(1)
+    ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time).to_f * 1000).round(1)
   end
 
   def self.sql_patches

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -195,7 +195,7 @@ describe Rack::MiniProfiler do
 
     it "should not store the original cache header if not set" do
       get '/html'
-      last_response.headers.should_not have_key('X-MiniProfiler-Original-Cache-Control')
+      expect(last_response.headers).to_not have_key('X-MiniProfiler-Original-Cache-Control')
     end
 
     it "should strip if-modified-since on the way in" do

--- a/spec/lib/client_settings_spec.rb
+++ b/spec/lib/client_settings_spec.rb
@@ -9,7 +9,7 @@ describe Rack::MiniProfiler::ClientSettings do
       @settings = Rack::MiniProfiler::ClientSettings.new(
         {"HTTP_COOKIE" => "__profilin=#{settings};" },
         @store,
-        Time.now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
       )
     end
 
@@ -59,7 +59,7 @@ describe Rack::MiniProfiler::ClientSettings do
       Rack::MiniProfiler.config.authorization_mode = :whitelist
       Rack::MiniProfiler.deauthorize_request
       hash = {}
-      Time.travel(Time.now + 1) do
+      clock_travel(Process.clock_gettime(Process::CLOCK_MONOTONIC) + 1) do
         @settings.handle_cookie([200, hash, []])
       end
 
@@ -68,7 +68,7 @@ describe Rack::MiniProfiler::ClientSettings do
   end
 
   it "should not have settings by default" do
-    expect(Rack::MiniProfiler::ClientSettings.new({}, Rack::MiniProfiler::MemoryStore.new, Time.now)
+    expect(Rack::MiniProfiler::ClientSettings.new({}, Rack::MiniProfiler::MemoryStore.new, Process.clock_gettime(Process::CLOCK_MONOTONIC))
       .has_valid_cookie?).to eq(false)
   end
 

--- a/spec/lib/profiler_spec.rb
+++ b/spec/lib/profiler_spec.rb
@@ -87,15 +87,17 @@ describe Rack::MiniProfiler do
 
     describe 'typical usage' do
       before(:all) do
-        Time.now = Time.new
+        start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        clock_set(start)
         Rack::MiniProfiler.create_current
-        Time.now += 1
+        clock_set(start + 1)
+
         Rack::MiniProfiler.step('outer') {
-          Time.now +=  2
+          clock_set(start + 1 + 2)
           Rack::MiniProfiler.step('inner') {
-            Time.now += 3
+            clock_set(start + 1 + 2 + 3)
           }
-          Time.now += 4
+          clock_set(start + 1 + 2 + 3 + 4)
         }
         @page_struct = Rack::MiniProfiler.current.page_struct
         @root = @page_struct.root
@@ -106,7 +108,7 @@ describe Rack::MiniProfiler do
       end
 
       after(:all) do
-        Time.back_to_normal
+        clock_back_to_normal
       end
 
       it 'measures total duration correctly' do

--- a/spec/lib/storage/file_store_spec.rb
+++ b/spec/lib/storage/file_store_spec.rb
@@ -18,13 +18,13 @@ describe Rack::MiniProfiler::FileStore do
         expect(tokens.length).to eq(1)
         expect(tokens).to eq(@store.allowed_tokens)
 
-        Time.travel(Time.now + 1) do
+        clock_travel(Process.clock_gettime(Process::CLOCK_MONOTONIC) + 1) do
           new_tokens = @store.allowed_tokens
           expect(new_tokens.length).to eq(1)
           expect(new_tokens).to eq(tokens)
         end
 
-        Time.travel(Time.now + Rack::MiniProfiler::AbstractStore::MAX_TOKEN_AGE + 1) do
+        clock_travel(Process.clock_gettime(Process::CLOCK_MONOTONIC) + Rack::MiniProfiler::AbstractStore::MAX_TOKEN_AGE + 1) do
           new_tokens = @store.allowed_tokens
           expect(new_tokens.length).to eq(2)
           expect((new_tokens - tokens).length).to eq(1)

--- a/spec/lib/storage/memcache_store_spec.rb
+++ b/spec/lib/storage/memcache_store_spec.rb
@@ -59,13 +59,13 @@ describe Rack::MiniProfiler::MemcacheStore do
       expect(tokens.length).to eq(1)
       expect(tokens).to eq(@store.allowed_tokens)
 
-      Time.travel(Time.now + 1) do
+      clock_travel(Process.clock_gettime(Process::CLOCK_MONOTONIC) + 1) do
         new_tokens = @store.allowed_tokens
         expect(new_tokens.length).to eq(1)
         expect(new_tokens).to eq(tokens)
       end
 
-      Time.travel(Time.now + Rack::MiniProfiler::AbstractStore::MAX_TOKEN_AGE + 1) do
+      clock_travel(Process.clock_gettime(Process::CLOCK_MONOTONIC) + Rack::MiniProfiler::AbstractStore::MAX_TOKEN_AGE + 1) do
         new_tokens = @store.allowed_tokens
         expect(new_tokens.length).to eq(2)
         expect((new_tokens - tokens).length).to eq(1)

--- a/spec/lib/storage/memory_store_spec.rb
+++ b/spec/lib/storage/memory_store_spec.rb
@@ -48,7 +48,7 @@ describe Rack::MiniProfiler::MemoryStore do
     end
 
     it "cleans up expired values" do
-      old_page_struct = {:id => "XYZ", :random => "random", :started => ((Time.now.to_f - 2) * 1000).to_i }
+      old_page_struct = {:id => "XYZ", :random => "random", :started => ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - 2) * 1000).to_i }
       @fast_expiring_store.save(old_page_struct)
       old_page_struct = @fast_expiring_store.load("XYZ")
       expect(old_page_struct[:id]).to eq("XYZ")
@@ -69,13 +69,13 @@ describe Rack::MiniProfiler::MemoryStore do
       expect(tokens.length).to eq(1)
       expect(tokens).to eq(@store.allowed_tokens)
 
-      Time.travel(Time.now + 1) do
+      clock_travel(Process.clock_gettime(Process::CLOCK_MONOTONIC) + 1) do
         new_tokens = @store.allowed_tokens
         expect(new_tokens.length).to eq(1)
         expect(new_tokens).to eq(tokens)
       end
 
-      Time.travel(Time.now + Rack::MiniProfiler::AbstractStore::MAX_TOKEN_AGE + 1) do
+      clock_travel(Process.clock_gettime(Process::CLOCK_MONOTONIC) + Rack::MiniProfiler::AbstractStore::MAX_TOKEN_AGE + 1) do
         new_tokens = @store.allowed_tokens
         expect(new_tokens.length).to eq(2)
         expect((new_tokens - tokens).length).to eq(1)


### PR DESCRIPTION
Basically just a search and replace along with a new helper that replaces `Time.travel`. I also fixed an unrelated test failure. 

I see there's another PR that updates the README in a similar fashion, so that will probably be a conflict.