### PR TITLE
Add `# frozen_string_literal: true` to all `lib/**/*.rb` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.10.8 2017-12-01
+
+- [FEATURE] Add `# frozen_string_literal: true` to all `lib/**/*.rb` files
+
 ## 0.10.7 2017-11-24
 
 - [FEATURE] Replace Time.now with Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/README.md
+++ b/README.md
@@ -4,14 +4,6 @@
 
 Middleware that displays speed badge for every html page. Designed to work both in production and in development.
 
-# URGENT HELP NEEDED!!!
-
-Well, not exactly mega urgent, but nice to see you are reading this.
-
-There is one very simple change I would like to see ASAP: I would like to see `# frozen_string_literal: true` on every file we ship
-
-If you pick up this task, be sure to amend the README in your PR AND add a Changelog. 
-
 #### Features
 
 * Database profiling - Currently supports Mysql2, Postgres, Oracle (oracle_enhanced ~> 1.5.0) and Mongoid3 (with fallback support to ActiveRecord)

--- a/lib/generators/rack_profiler/install_generator.rb
+++ b/lib/generators/rack_profiler/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RackProfiler
   module Generators
     class InstallGenerator < ::Rails::Generators::Base

--- a/lib/generators/rack_profiler/templates/rack_profiler.rb
+++ b/lib/generators/rack_profiler/templates/rack_profiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if Rails.env.development?
   require "rack-mini-profiler"
 

--- a/lib/mini_profiler/asset_version.rb
+++ b/lib/mini_profiler/asset_version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
-    ASSET_VERSION = '812af6927f7534f73488ece21dc89b62'.freeze
+    ASSET_VERSION = '812af6927f7534f73488ece21dc89b62'
   end
 end

--- a/lib/mini_profiler/client_settings.rb
+++ b/lib/mini_profiler/client_settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     class ClientSettings

--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -1,4 +1,4 @@
-#frozen_string_literal: true
+# frozen_string_literal: true
 
 module Rack
   class MiniProfiler
@@ -16,7 +16,7 @@ module Rack
       def self.default
         new.instance_eval {
           @auto_inject      = true # automatically inject on every html page
-          @base_url_path    = "/mini-profiler-resources/"
+          @base_url_path    = "/mini-profiler-resources/".dup
           @disable_caching  = true
           # called prior to rack chain, to ensure we are allowed to profile
           @pre_authorize_cb = lambda {|env| true}

--- a/lib/mini_profiler/context.rb
+++ b/lib/mini_profiler/context.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rack::MiniProfiler::Context
   attr_accessor :inject_js,:current_timer,:page_struct,:skip_backtrace,
                 :full_backtrace,:discard, :mpt_init, :measure

--- a/lib/mini_profiler/gc_profiler.rb
+++ b/lib/mini_profiler/gc_profiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rack::MiniProfiler::GCProfiler
 
   def initialize

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     class << self
@@ -406,7 +408,7 @@ module Rack
     end
 
     def dump_exceptions(exceptions)
-      body = "Exceptions raised during request\n\n"
+      body = "Exceptions raised during request\n\n".dup
       if exceptions.empty?
         body << "No exceptions raised"
       else
@@ -424,7 +426,7 @@ module Rack
     end
 
     def dump_env(env)
-      body = "Rack Environment\n---------------\n"
+      body = "Rack Environment\n---------------\n".dup
       env.each do |k,v|
         body << "#{k}: #{v}\n"
       end
@@ -475,7 +477,7 @@ module Rack
         str
       end
 
-      body = "ObjectSpace stats:\n\n"
+      body = "ObjectSpace stats:\n\n".dup
 
       counts = ObjectSpace.count_objects
       total_strings = counts[:T_STRING]

--- a/lib/mini_profiler/profiling_methods.rb
+++ b/lib/mini_profiler/profiling_methods.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     module ProfilingMethods

--- a/lib/mini_profiler/storage/abstract_store.rb
+++ b/lib/mini_profiler/storage/abstract_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     class AbstractStore

--- a/lib/mini_profiler/storage/file_store.rb
+++ b/lib/mini_profiler/storage/file_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     class FileStore < AbstractStore

--- a/lib/mini_profiler/storage/memcache_store.rb
+++ b/lib/mini_profiler/storage/memcache_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     class MemcacheStore < AbstractStore

--- a/lib/mini_profiler/storage/memory_store.rb
+++ b/lib/mini_profiler/storage/memory_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     class MemoryStore < AbstractStore

--- a/lib/mini_profiler/storage/redis_store.rb
+++ b/lib/mini_profiler/storage/redis_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     class RedisStore < AbstractStore

--- a/lib/mini_profiler/timer_struct/base.rb
+++ b/lib/mini_profiler/timer_struct/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     module TimerStruct

--- a/lib/mini_profiler/timer_struct/client.rb
+++ b/lib/mini_profiler/timer_struct/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     module TimerStruct
@@ -15,7 +17,7 @@ module Rack
 
         # used by Railtie to instrument asset_tag for JS / CSS
         def self.instrument(name, orig)
-          probe = "<script>mPt.probe('#{name}')</script>"
+          probe = "<script>mPt.probe('#{name}')</script>".dup
           wrapped = probe
           wrapped << orig
           wrapped << probe

--- a/lib/mini_profiler/timer_struct/custom.rb
+++ b/lib/mini_profiler/timer_struct/custom.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     module TimerStruct

--- a/lib/mini_profiler/timer_struct/page.rb
+++ b/lib/mini_profiler/timer_struct/page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     module TimerStruct

--- a/lib/mini_profiler/timer_struct/request.rb
+++ b/lib/mini_profiler/timer_struct/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     module TimerStruct

--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -11,7 +11,7 @@ module Rack
           stack_trace = nil
           unless skip_backtrace || duration_ms < Rack::MiniProfiler.config.backtrace_threshold_ms
             # Allow us to filter the stack trace
-            stack_trace = String.new.dup
+            stack_trace = "".dup
              # Clean up the stack trace if there are options to do so
             Kernel.caller.each do |ln|
               ln.gsub!(Rack::MiniProfiler.config.backtrace_remove, '') if Rack::MiniProfiler.config.backtrace_remove and !full_backtrace

--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -11,7 +11,7 @@ module Rack
           stack_trace = nil
           unless skip_backtrace || duration_ms < Rack::MiniProfiler.config.backtrace_threshold_ms
             # Allow us to filter the stack trace
-            stack_trace = String.new
+            stack_trace = String.new.dup
              # Clean up the stack trace if there are options to do so
             Kernel.caller.each do |ln|
               ln.gsub!(Rack::MiniProfiler.config.backtrace_remove, '') if Rack::MiniProfiler.config.backtrace_remove and !full_backtrace

--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Rack
   class MiniProfiler
 

--- a/lib/mini_profiler/version.rb
+++ b/lib/mini_profiler/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rack
   class MiniProfiler
     VERSION = '0.10.7'

--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'fileutils'
 
 module Rack::MiniProfilerRails

--- a/lib/patches/db/activerecord.rb
+++ b/lib/patches/db/activerecord.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ## based off https://github.com/newrelic/rpm/blob/master/lib/new_relic/agent/instrumentation/active_record.rb
 ## fallback for alls sorts of weird dbs
 module Rack

--- a/lib/patches/db/mongo.rb
+++ b/lib/patches/db/mongo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Mongo/Mongoid 5 patches
 class Mongo::Server::Connection
   def dispatch_with_timing(*args, &blk)

--- a/lib/patches/db/moped.rb
+++ b/lib/patches/db/moped.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Mongoid 3 patches
 class Moped::Node
   alias_method :process_without_profiling, :process

--- a/lib/patches/db/mysql2.rb
+++ b/lib/patches/db/mysql2.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The best kind of instrumentation is in the actual db provider, however we don't want to double instrument
 
 class Mysql2::Result

--- a/lib/patches/db/neo4j.rb
+++ b/lib/patches/db/neo4j.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Neo4j::Core::Query
   alias_method :response_without_miniprofiler, :response
 

--- a/lib/patches/db/nobrainer.rb
+++ b/lib/patches/db/nobrainer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Rack::MiniProfiler::NoBrainerProfiler
 
   def on_query(env)
@@ -6,7 +8,7 @@ class Rack::MiniProfiler::NoBrainerProfiler
                         !env[:criteria].where_indexed? &&
                         !env[:criteria].model.try(:perf_warnings_disabled)
 
-      query = ""
+      query = "".dup
 
       # per-model/query database overrides
       query << "[#{env[:options][:db]}] " if env[:options][:db]

--- a/lib/patches/db/oracle_enhanced.rb
+++ b/lib/patches/db/oracle_enhanced.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ActiveRecord::Result
   alias_method :each_without_profiling, :each
   def each(&blk)

--- a/lib/patches/db/pg.rb
+++ b/lib/patches/db/pg.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # PG patches, keep in mind exec and async_exec have a exec{|r| } semantics that is yet to be implemented
 class PG::Result
   alias_method :each_without_profiling, :each

--- a/lib/patches/db/plucky.rb
+++ b/lib/patches/db/plucky.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # mongo_mapper patches
 # TODO: Include overrides for distinct, update, cursor, and create
 class Plucky::Query

--- a/lib/patches/db/riak.rb
+++ b/lib/patches/db/riak.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # riak-client 2.2.2 patches
 class Riak::Multiget
   class <<self

--- a/lib/patches/db/rsolr.rb
+++ b/lib/patches/db/rsolr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RSolr::Connection
   alias_method :execute_without_profiling, :execute
   def execute_with_profiling(client, request_context)
@@ -7,7 +9,7 @@ class RSolr::Connection
     result       = execute_without_profiling(client, request_context)
     elapsed_time = SqlPatches.elapsed_time(start)
 
-    data = "#{request_context[:method].upcase} #{request_context[:uri]}"
+    data = "#{request_context[:method].upcase} #{request_context[:uri]}".dup
     if request_context[:method] == :post and request_context[:data]
       if request_context[:headers].include?("Content-Type") and request_context[:headers]["Content-Type"] == "text/xml"
         # it's xml, unescaping isn't needed

--- a/lib/patches/db/sequel.rb
+++ b/lib/patches/db/sequel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Sequel
   class Database
     alias_method :log_duration_original, :log_duration

--- a/lib/patches/net_patches.rb
+++ b/lib/patches/net_patches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if (defined?(Net) && defined?(Net::HTTP))
 
   Net::HTTP.class_eval do

--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SqlPatches
   def self.correct_version?(required_version, klass)
     Gem::Dependency.new('', required_version).match?('', klass::VERSION)

--- a/lib/rack-mini-profiler.rb
+++ b/lib/rack-mini-profiler.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require 'timeout'
 require 'thread'

--- a/spec/integration/middleware_spec.rb
+++ b/spec/integration/middleware_spec.rb
@@ -22,6 +22,20 @@ describe Rack::MiniProfiler do
     end
   end
 
+  describe 'with analyze-memory query' do
+    def app
+      Rack::Builder.new do
+        use Rack::MiniProfiler
+        run lambda { |_env| [200, {'Content-Type' => 'text/html'}, ['<html><body><h1>Hi</h1></body></html>']] }
+      end
+    end
+
+    it 'should return ObjectSpace statistics' do
+      do_get(:pp=>'analyze-memory')
+      expect(last_response.body).to include('Largest strings:')
+    end
+  end
+
   describe 'with Rack::MiniProfiler before Rack::Deflater' do
     def app
       Rack::Builder.new do


### PR DESCRIPTION
Knowing that there is another PR out for this fix (https://github.com/MiniProfiler/rack-mini-profiler/pull/319), feel free to deprioritize this fix.

A few notable differences:
1. Used `.dup` instead of switching `<<` to `+=` to cut down on diff
2. Did not add `# frozen_string_literal: true` to spec files (was this something that was wanted?)

Also noticed that there were a few strings that should have failed, but didn't due to lack of coverage around those methods. We found this in:
1. `execute_with_profiling` in `lib/patches/db/rsolr.rb:12`
2. ~~`analyze_memory` in `lib/mini_profiler/profiler.rb:480`~~
3. `on_query` in `lib/patches/db/nobrainer.rb:11`
4. ~~`initialize` in `lib/mini_profiler/timer_struct/sql.rb:14`~~ I was wrong, this was covered

Thank you so much for maintaining this awesome gem!