### PR TITLE
Store profiler visibility preference for a session

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -402,6 +402,7 @@ var MiniProfiler = (function () {
         });
         $(document).on('keydown.mini-profiler', null, options.toggleShortcut, function(e) {
             $('.profiler-results').toggle();
+            sessionStorage['rack-mini-profiler-start-hidden'] = $('.profiler-results').is(':hidden');
         });
 
         if (typeof Turbolinks !== 'undefined' && Turbolinks.supported) {
@@ -636,7 +637,7 @@ var MiniProfiler = (function () {
                 var children = script.getAttribute('data-children') === 'true';
                 var controls = script.getAttribute('data-controls') === 'true';
                 var authorized = script.getAttribute('data-authorized') === 'true';
-                var startHidden = script.getAttribute('data-start-hidden') === 'true';
+                var startHidden = script.getAttribute('data-start-hidden') === 'true' || sessionStorage['rack-mini-profiler-start-hidden'] === 'true';
                 var htmlContainer = script.getAttribute('data-html-container');
 
                 return {


### PR DESCRIPTION
I thought it would be neat when a user presses `alt + p`, it stores the profiler visibility preference for their entire session instead of just on that page load.

What do you think?