### PR TITLE
Fix page start time

### DIFF
--- a/lib/mini_profiler/timer_struct/page.rb
+++ b/lib/mini_profiler/timer_struct/page.rb
@@ -13,12 +13,14 @@ module Rack
         def initialize(env)
           timer_id     = MiniProfiler.generate_id
           page_name    = env['PATH_INFO']
-          started_at   = (Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1000).to_i
+          started_at   = (Time.now.to_f * 1000).to_i
+          started      = (Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1000).to_i
           machine_name = env['SERVER_NAME']
           super(
             :id                                      => timer_id,
             :name                                    => page_name,
-            :started                                 => started_at,
+            :started                                 => started,
+            :started_at                              => started_at,
             :machine_name                            => machine_name,
             :level                                   => 0,
             :user                                    => "unknown user",
@@ -68,7 +70,7 @@ module Rack
 
         def extra_json
           {
-            :started               => '/Date(%d)/' % @attributes[:started],
+            :started               => '/Date(%d)/' % @attributes.delete(:started_at),
             :duration_milliseconds => @attributes[:root][:duration_milliseconds],
             :custom_timing_names   => @attributes[:custom_timing_stats].keys.sort
           }

--- a/spec/lib/timer_struct/page_timer_struct_spec.rb
+++ b/spec/lib/timer_struct/page_timer_struct_spec.rb
@@ -20,6 +20,7 @@ describe Rack::MiniProfiler::TimerStruct::Page do
 
     it 'has a Started element' do
       expect(@deserialized['started']).not_to be_nil
+      expect(@deserialized['started']).to match(/Date\(\d{13}\)/)
     end
 
     it 'has a DurationMilliseconds element' do


### PR DESCRIPTION
hi, i  find the profiler ui on `includes.tmpl`, the start time is not correct, it use `Process.clock_gettime` for initialize `Date`, so i  do that:
``` ruby
# page.rb
def initialize
  ...
  started_at   = (Time.now.to_f * 1000).to_i
  started      = (Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1000).to_i
  ...
end

...

def extra_json
  ....
  :started   => '/Date(%d)/' % @attributes.delete(:started_at)
  ... 
end
```
i hope that have a suggestion from you soon. thanks.