### PR TITLE
Don't subtract top from windowHeight in popupSetDimensions

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -254,7 +254,7 @@ var MiniProfiler = (function () {
     var popupSetDimensions = function (button, popup) {
         var px = button.position().top - 1, // position next to the button we clicked
             windowHeight = $(window).height(),
-            maxHeight = windowHeight - top - 40; // make sure the popup doesn't extend below the fold
+            maxHeight = windowHeight - 40; // make sure the popup doesn't extend below the fold
 
         popup
             .css(options.renderVerticalPosition, px)


### PR DESCRIPTION
This was breaking the popup from working when rendered in an iframe. It would spit out an error like this:

```
VM137461:1 Uncaught DOMException: Blocked a frame with origin "http://localhost:4000" from accessing a cross-origin frame.
    at eval (eval at popupSetDimensions (http://localhost:4000/mini-profiler-resources/includes.js?v=812af6927f7534f73488ece21dc89b62:257:9), <anonymous>:1:14)
```

I believe the `maxHeight` variable wasn't working properly anyway, as `windowHeight - top - 40` return `NaN` when not in an iframe.