### PR TITLE
Add support for the new javascript fetch API

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -603,20 +603,20 @@ var MiniProfiler = (function () {
               __originalFetch(input,init).then(function(response) {
                 // look for x-mini-profile-ids
                 for (var pair of response.headers.entries()) {
-                  if(pair[0] == 'X-MiniProfiler-Ids') {
+                  if(pair[0] && (pair[0].toLowerCase() == 'x-miniprofiler-ids')) {
                   var ids = JSON.parse(pair[1]);
                     fetchResults(ids);
                   }
                 }
-                resolve(response);  
+                resolve(response);
               }).catch(function(error) {
                 reject(error);
-              });	
+              });
             });
           }
           window.fetch.__patchedByMiniProfiler = true;
         }
-        
+
         // some elements want to be hidden on certain doc events
         bindDocumentEvents();
     };
@@ -844,7 +844,7 @@ var MiniProfiler = (function () {
             // Use the Paint Timing API for render performance.
             if (window.performance) {
               var firstPaint = window.performance.getEntriesByName("first-paint");
-              
+
               if(firstPaint !== undefined && firstPaint.length >= 1){
                 list.push(
                   {

--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -592,6 +592,31 @@ var MiniProfiler = (function () {
           };
         }
 
+        // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+        if(typeof(window.fetch) === 'function' && window.fetch.__patchedByMiniProfiler === undefined) {
+          var __originalFetch = window.fetch;
+
+          console.warn('alert: patching window.fetch for profiling');
+
+          window.fetch = function(input,init) {
+            return new Promise(function(resolve,reject) {
+              __originalFetch(input,init).then(function(response) {
+                // look for x-mini-profile-ids
+                for (var pair of response.headers.entries()) {
+                  if(pair[0] == 'X-MiniProfiler-Ids') {
+                  var ids = JSON.parse(pair[1]);
+                    fetchResults(ids);
+                  }
+                }
+                resolve(response);  
+              }).catch(function(error) {
+                reject(error);
+              });	
+            });
+          }
+          window.fetch.__patchedByMiniProfiler = true;
+        }
+        
         // some elements want to be hidden on certain doc events
         bindDocumentEvents();
     };

--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -596,8 +596,6 @@ var MiniProfiler = (function () {
         if(typeof(window.fetch) === 'function' && window.fetch.__patchedByMiniProfiler === undefined) {
           var __originalFetch = window.fetch;
 
-          console.warn('alert: patching window.fetch for profiling');
-
           window.fetch = function(input,init) {
             return new Promise(function(resolve,reject) {
               __originalFetch(input,init).then(function(response) {


### PR DESCRIPTION
## Proposed solution for #348. 

Add support for the new `fetch` API so we capture the `x-miniprofiler-ids` from the fetch response headers. Fetch is promise based, so we wrap it when mini profiler is enabled and setup the promise chain to first inspect it for profiling purposes and then pass on the response (or errors) to the original promise chain.

I've tested this and confirmed it works in a react app we have that is using the fetch API the mini profiler (the fact that the app is react is inconsequential to how this works).