### PR TITLE
Fix for user agents which does not has Performance.getEntriesByName

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -817,7 +817,7 @@ var MiniProfiler = (function () {
 
 
             // Use the Paint Timing API for render performance.
-            if (window.performance) {
+            if (window.performance && window.performance.getEntriesByName) {
               var firstPaint = window.performance.getEntriesByName("first-paint");
               
               if(firstPaint !== undefined && firstPaint.length >= 1){


### PR DESCRIPTION
In iOS 9.3, window.performance exists but
window.performance.getEntriesByName does not.

![2018-05-23 18 48 41](https://user-images.githubusercontent.com/5965113/40417664-37ec59ec-5ebb-11e8-8923-87c696470929.png)
![2018-05-23 18 59 42](https://user-images.githubusercontent.com/5965113/40417767-89bd42ae-5ebb-11e8-95f8-3b7fdaec33b1.png)
