### PR TITLE
Add mini-profiler-only route example

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,27 @@ You need to inject the following in your SPA to load MiniProfiler's speed badge 
 
 _Note:_ The GUID (`data-version` and the `?v=` parameter on the `src`) will change with each release of `rack_mini_profiler`. The MiniProfiler's speed badge will continue to work, although you will have to change the GUID to expire the script to fetch the most recent version.
 
+The below example will always use the correct GUID and will serve the badge at `/profiler`.
+
+```ruby
+# config/initializers/mini_profiler.rb
+  Rails.application.routes.append do
+    mini_profiler = Rack::MiniProfiler.new(Rails.application)
+    get '/profiler' => ->(env) {
+      # NOTE: handle any authorization here
+      [200, {}, [<<-BODY.strip_heredoc]]
+      <html>
+      <head>
+      </head>
+      <body>
+      #{mini_profiler.get_profile_script(env)}
+      </body>
+      </html>
+      BODY
+    }
+  end
+``` 
+
 ### Configuration Options
 
 You can set configuration options using the configuration accessor on `Rack::MiniProfiler`.


### PR DESCRIPTION
see https://github.com/MiniProfiler/rack-mini-profiler/blob/1bd8c9fe64940ad514f8f965f7e036c6d8b9d910/README.md#miniprofilers-speed-badge-on-pages-that-are-not-generated-via-rails


per https://github.com/MiniProfiler/rack-mini-profiler/issues/139#issuecomment-192880706