### PR TITLE
Amends color of .profiler-unit to pass lighthouse accessibility audit

### DIFF
--- a/lib/html/includes.css
+++ b/lib/html/includes.css
@@ -35,11 +35,11 @@
     overflow: hidden;
     text-overflow: ellipsis; }
   .profiler-result .profiler-unit {
-    color: #555; }
+    color: #767676; }
   .profiler-result .profiler-trivial {
     display: none; }
     .profiler-result .profiler-trivial td, .profiler-result .profiler-trivial td * {
-      color: #aaa !important; }
+      color: #767676 !important; }
   .profiler-result pre, .profiler-result code, .profiler-result .profiler-number, .profiler-result .profiler-unit {
     font-family: Consolas, monospace, serif; }
   .profiler-result .profiler-number {
@@ -52,7 +52,7 @@
       white-space: nowrap; }
   .profiler-result .profiler-timings th {
     background-color: #fff;
-    color: #aaa;
+    color: #767676;
     text-align: right; }
   .profiler-result .profiler-timings th, .profiler-result .profiler-timings td {
     white-space: nowrap; }
@@ -228,7 +228,7 @@
     cursor: default;
     text-align: center; }
     .profiler-results .profiler-controls span {
-      border-right: 1px solid #aaa;
+      border-right: 1px solid #767676;
       padding-right: 5px;
       margin-right: 5px;
       cursor: pointer; }
@@ -306,7 +306,7 @@
     display: none; }
   .profiler-result-full .profiler-result .profiler-popup .profiler-info {
     font-size: 25px;
-    border-bottom: 1px solid #aaa;
+    border-bottom: 1px solid #767676;
     padding-bottom: 3px;
     margin-bottom: 25px; }
     .profiler-result-full .profiler-result .profiler-popup .profiler-info .profiler-overall-duration {

--- a/lib/html/includes.css
+++ b/lib/html/includes.css
@@ -35,7 +35,7 @@
     overflow: hidden;
     text-overflow: ellipsis; }
   .profiler-result .profiler-unit {
-    color: #aaa; }
+    color: #555; }
   .profiler-result .profiler-trivial {
     display: none; }
     .profiler-result .profiler-trivial td, .profiler-result .profiler-trivial td * {

--- a/lib/html/includes.scss
+++ b/lib/html/includes.scss
@@ -67,7 +67,7 @@ $zindex:2147483640; // near 32bit max 2147483647
     }
 
     .profiler-unit {
-        color:$mutedColor;
+        color:$textColor;
     }
 
     .profiler-trivial {

--- a/lib/html/includes.scss
+++ b/lib/html/includes.scss
@@ -8,7 +8,7 @@ $anchorColor: #0077CC;
 $buttonBorderColor: #888;
 $numberColor: #111;
 $textColor: #555;
-$mutedColor: #aaa;
+$mutedColor: #767676;
 $normalFonts: Helvetica, Arial, sans-serif;
 $codeFonts: Consolas, monospace, serif;
 $zindex:2147483640; // near 32bit max 2147483647
@@ -67,7 +67,7 @@ $zindex:2147483640; // near 32bit max 2147483647
     }
 
     .profiler-unit {
-        color:$textColor;
+        color:$mutedColor;
     }
 
     .profiler-trivial {


### PR DESCRIPTION
The current style prevents a successful accessibility audit in google lighthouse due to the contrast ratio of the unit (**ms** for example).
Not only does it seem like a good idea to remedy this for usability sake but also to make it less troublesome when running accessibility audits on local projects.

This pr simply uses $textColor (#555) rather than $mutedColor (#aaa) in the css.