### PR TITLE
fix missing started_at on request

### DIFF
--- a/lib/mini_profiler/timer_struct/page.rb
+++ b/lib/mini_profiler/timer_struct/page.rb
@@ -71,7 +71,7 @@ module Rack
 
         def extra_json
           {
-            :started               => '/Date(%d)/' % @attributes.delete(:started_at),
+            :started               => '/Date(%d)/' % @attributes[:started_at],
             :duration_milliseconds => @attributes[:root][:duration_milliseconds],
             :custom_timing_names   => @attributes[:custom_timing_stats].keys.sort
           }


### PR DESCRIPTION
In #333 the `started_at` attribute it deleted from the `Page` struct(https://github.com/MiniProfiler/rack-mini-profiler/pull/333/files#diff-f8c72372f6f62551dbeeb2ac29be1152R73), and it causes a `nil` issue in some cases. I couldn't really find in the code where this happens(probably `to_json` is called twice on the struct in some cases), but we have a bunch of #354  in production.