### PR TITLE
Add Rubocop and Enable Performance Cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+AllCops:
+  DisabledByDefault: true
+  TargetRubyVersion: 2.2
+  Include:
+    - 'lib/**/*.rb'
+
+Performance:
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,11 @@ require 'bundler/gem_tasks'
 
 Bundler.setup(:default, :test)
 
-task :default => [:spec]
+require 'rubocop/rake_task'
+
+RuboCop::RakeTask.new
+
+task :default => [:rubocop, :spec]
 
 require 'rspec/core'
 require 'rspec/core/rake_task'

--- a/lib/mini_profiler/storage/file_store.rb
+++ b/lib/mini_profiler/storage/file_store.rb
@@ -30,7 +30,7 @@ module Rack
         private
         if RUBY_PLATFORM =~ /mswin(?!ce)|mingw|cygwin|bccwin/
           def path(key)
-            @path + "/" + @prefix  + "_" + key.gsub(/:/, '_')
+            @path + "/" + @prefix  + "_" + key.tr(':', '_')
           end
         else
           def path(key)

--- a/lib/patches/db/nobrainer.rb
+++ b/lib/patches/db/nobrainer.rb
@@ -17,7 +17,7 @@ class Rack::MiniProfiler::NoBrainerProfiler
       # query << "(#{NoBrainer::RQL.type_of(env[:query]).to_s}) "
 
       query << "NOT USING INDEX: " if not_indexed
-      query << env[:query].inspect.gsub(/\n/, '').gsub(/ +/, ' ') + " "
+      query << env[:query].inspect.delete("\n").gsub(/ +/, ' ') + " "
 
       if env[:exception]
         query << "exception: #{env[:exception].class} #{env[:exception].message.split("\n").first} "

--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'redis'
   s.add_development_dependency 'sass'
   s.add_development_dependency 'flamegraph'
+  s.add_development_dependency 'rubocop'
 
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
Found 2 offenses on first run:

```
$ rubocop --auto-correct
Inspecting 40 files
...........C.......................C....

Offenses:

lib/patches/db/nobrainer.rb:20:36: C: [Corrected] Performance/StringReplacement: Use delete instead of gsub.
      query << env[:query].inspect.gsub(/\n/, '').gsub(/ +/, ' ') + " "
                                   ^^^^^^^^^^^^^^
lib/mini_profiler/storage/file_store.rb:33:48: C: [Corrected] Performance/StringReplacement: Use tr instead of gsub.
            @path + "/" + @prefix  + "_" + key.gsub(/:/, '_')
                                               ^^^^^^^^^^^^^^

40 files inspected, 2 offenses detected, 2 offenses corrected
```