### PR TITLE
Allow filtering of stack frames in flamegraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ toggle_shortcut|Alt+P|Keyboard shortcut to toggle the mini_profiler's visibility
 start_hidden|`false`|`false` to make mini_profiler visible on page load.
 backtrace_threshold_ms|`0`|Minimum SQL query elapsed time before a backtrace is recorded.
 flamegraph_sample_rate|`0.5`|How often to capture stack traces for flamegraphs in milliseconds.
+flamegraph_file_filter|`nil`|Base file path for stack frames to include in flamegraphs.
 disable_env_dump|`false`|`true` disables `?pp=env`, which prevents sending ENV vars over HTTP.
 base_url_path|`'/mini-profiler-resources/'`|Path for assets; added as a prefix when naming assets and sought when responding to requests.
 collapse_results|`true`|If multiple timing results exist in a single page, collapse them till clicked.

--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -28,6 +28,7 @@ module Rack
           @authorization_mode     = :allow_all
           @backtrace_threshold_ms = 0
           @flamegraph_sample_rate = 0.5
+          @flamegraph_file_filter = nil
           @storage_failure = Proc.new do |exception|
             if @logger
               @logger.warn("MiniProfiler storage failure: #{exception.message}")
@@ -58,7 +59,7 @@ module Rack
       attr_accessor :authorization_mode, :auto_inject, :backtrace_ignores,
         :backtrace_includes, :backtrace_remove, :backtrace_threshold_ms,
         :base_url_path, :disable_caching, :disable_env_dump, :enabled,
-        :flamegraph_sample_rate, :logger, :pre_authorize_cb, :skip_paths,
+        :flamegraph_sample_rate, :flamegraph_file_filter, :logger, :pre_authorize_cb, :skip_paths,
         :skip_schema_queries, :storage, :storage_failure, :storage_instance,
         :storage_options, :user_provider
       attr_accessor :skip_sql_param_names, :suppress_encoding, :max_sql_param_length

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -277,7 +277,14 @@ module Rack
             else
               sample_rate = config.flamegraph_sample_rate
             end
-            flamegraph = Flamegraph.generate(nil, :fidelity => sample_rate, :embed_resources => query_string =~ /embed/, :mode => mode) do
+            flamegraph =
+              Flamegraph.generate(
+                nil,
+                :fidelity => sample_rate,
+                :embed_resources => query_string =~ /embed/,
+                :mode => mode,
+                :filter_path => config.flamegraph_file_filter
+              ) do
               status,headers,body = @app.call(env)
             end
           end


### PR DESCRIPTION
For some larger Rails applications, the flamegraph can be pretty
overwhelming and full of non-application-related stack frames. While
that information is often valuable, at other times it's really helpful
to be able to see a simpler view of a smaller subset of the entire
process.

This leverages the changes added to flamegraph in
https://github.com/SamSaffron/flamegraph/pull/21 and adds a
rack-mini-profiler configuration to pass through to flamegraph to
achieve the above goal.