### PR TITLE
fix the way that fetch is patched

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -601,22 +601,25 @@ var MiniProfiler = (function () {
           var __originalFetch = window.fetch;
 
           window.fetch = function(input,init) {
-            return new Promise(function(resolve,reject) {
-              __originalFetch(input,init).then(function(response) {
-                // look for x-mini-profile-ids
-                var entries = response.headers.entries();
-                for (var i = 0; i < entries.length; i++) {
-                  var pair = entries[i];
-                  if(pair[0] && (pair[0].toLowerCase() == 'x-miniprofiler-ids')) {
-                  var ids = JSON.parse(pair[1]);
-                    fetchResults(ids);
+              var originalFetchRun = __originalFetch(input,init)
+              
+              originalFetchRun.then(function(response) {
+                  try {
+                      // look for x-mini-profile-ids
+                      var entries = response.headers.entries();
+                      for (var i = 0; i < entries.length; i++) {
+                          var pair = entries[i];
+                          if(pair[0] && (pair[0].toLowerCase() == 'x-miniprofiler-ids')) {
+                              var ids = JSON.parse(pair[1]);
+                              fetchResults(ids);
+                          }
+                      }
+                  } catch (e} {
+                      console.error(e)
                   }
-                }
-                resolve(response);
-              }).catch(function(error) {
-                reject(error);
-              });
-            });
+              })
+              
+              return originalFetchRun
           }
           window.fetch.__patchedByMiniProfiler = true;
         }


### PR DESCRIPTION
You should not be directly overwriting fetch in a way that returns something other than the original fetch. especially since clients might have added additional functionality to the original fetch function