### PR TITLE
Use Gem windows platform detector

### DIFF
--- a/lib/mini_profiler/storage/file_store.rb
+++ b/lib/mini_profiler/storage/file_store.rb
@@ -31,7 +31,7 @@ module Rack
         end
 
         private
-        if RUBY_PLATFORM =~ /mswin(?!ce)|mingw|cygwin|bccwin/
+	if Gem.win_platform?
           def path(key)
             @path.dup << "/" << @prefix << "_" << key.gsub(/:/, '_')
           end

--- a/lib/mini_profiler/storage/file_store.rb
+++ b/lib/mini_profiler/storage/file_store.rb
@@ -31,7 +31,7 @@ module Rack
         end
 
         private
-	if Gem.win_platform?
+        if Gem.win_platform?
           def path(key)
             @path.dup << "/" << @prefix << "_" << key.gsub(/:/, '_')
           end


### PR DESCRIPTION
I was running rails on windows using jruby, which returned my `RUBY_PLATFORM` as `java`.  This was not detected as being windows in the file writer, and therefore was trying to write out a file `mp_views_0:0:0:0:0:0:0:1` when using the filestore.  A `:` is an invalid character to have a filename in windows.
There is a check for this already, but doesn't handle the edge case of java on windows.  
I've updated the check to use `Gem.win_platform?` which uses the patterns [here](https://github.com/rubygems/rubygems/blob/ac20ec2c0972569c76c7d344b0029016fcf5892f/lib/rubygems.rb#L123).  The patterns include those that were already explicitly checked in this method.