### PR TITLE
☠️  rip sass ☠️  🎉 long live sassc 🎉 

### DIFF
--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'dalli'
   s.add_development_dependency 'rspec', '~> 3.6.0'
   s.add_development_dependency 'redis'
-  s.add_development_dependency 'sass'
+  s.add_development_dependency 'sassc'
   s.add_development_dependency 'flamegraph'
   s.add_development_dependency 'rubocop'
 


### PR DESCRIPTION
After a bundle install we get this message: 

```
Ruby Sass has reached end-of-life and should no longer be used.
* If you use Sass as a command-line tool, we recommend using Dart Sass, the new
  primary implementation: https://sass-lang.com/install
* If you use Sass as a plug-in for a Ruby web framework, we recommend using the
  sassc gem: https://github.com/sass/sassc-ruby#readme
* For more details, please refer to the Sass blog:
  https://sass-lang.com/blog/posts/7828841
```

This replaces it with the recommend `sassc` gem, I had a look at `includes.scss`  and I wasn't able to immediately spot anything that breaks compatibility, the `compile_sass` `rake` task should also keep working without changing anyting. Did a quick test with a `?pp=flamegraph` and all looked good. 

Fixes: https://github.com/MiniProfiler/rack-mini-profiler/issues/372