### PR TITLE
Disable Style/FrozenStringLiteralComment cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,4 @@
 inherit_from: https://raw.githubusercontent.com/discourse/discourse/master/.rubocop.yml
+
+Style/FrozenStringLiteralComment:
+  Enabled: false


### PR DESCRIPTION
#382 is failing due to the rubocop issue.
This fixes it.

By the way, I think the current RuboCop settings are not good for contributors.
Followings are uncontrollable and make build fragile simply.
1. [We don't specify the rubocop version](https://github.com/MiniProfiler/rack-mini-profiler/blob/08ad0c798f40588586c5b841491481fefd847b1c/rack-mini-profiler.gemspec#L37)
2. [.rubocop.yml is inheriting from another repository](https://github.com/MiniProfiler/rack-mini-profiler/blob/08ad0c798f40588586c5b841491481fefd847b1c/.rubocop.yml#L1)
