### PR TITLE
Avoid deprecated use of Rack::Request#[]

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -84,11 +84,11 @@ module Rack
 
     def serve_results(env)
       request     = Rack::Request.new(env)
-      id          = request[:id]
+      id          = request.params['id']
       page_struct = @storage.load(id)
       unless page_struct
         @storage.set_viewed(user(env), id)
-        id        = ERB::Util.html_escape(request['id'])
+        id        = ERB::Util.html_escape(request.params['id'])
         user_info = ERB::Util.html_escape(user(env))
         return [404, {}, ["Request not found: #{id} - user #{user_info}"]]
       end


### PR DESCRIPTION
When running Ruby in verbose mode ($VERBOSE = true) you can see a warning:
> WARNING Request#[] is deprecated and will be removed in a future version of Rack. Please use request.params[] instead

See https://github.com/rack/rack/pull/1069

"Params" hash must be accessed with string keys, there is no implicit conversion from symbols.
