### PR TITLE
Enable Ruby verbose mode in specs

### DIFF
--- a/spec/lib/profiler_spec.rb
+++ b/spec/lib/profiler_spec.rb
@@ -50,17 +50,18 @@ describe Rack::MiniProfiler do
   end
 
   describe 'profile method' do
+    class TestClass
+      def foo(bar, baz)
+        return [bar, baz, yield]
+      end
+
+      def self.bar(baz, boo)
+        return [baz, boo, yield]
+      end
+    end
+
     before do
       Rack::MiniProfiler.create_current
-      class TestClass
-        def foo(bar, baz)
-          return [bar, baz, yield]
-        end
-
-        def self.bar(baz, boo)
-          return [baz, boo, yield]
-        end
-      end
     end
 
     it 'should not destroy a method' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,6 +53,7 @@ module Process
     end
     module_function :clock_travel
 
+    undef clock_gettime
     def clock_gettime(*)
       @now || old_clock_gettime(Process::CLOCK_MONOTONIC)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+$VERBOSE = true
 require 'simplecov'
 SimpleCov.start do
   add_filter "/spec/"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,7 +55,7 @@ module Process
 
     undef clock_gettime
     def clock_gettime(*)
-      @now || old_clock_gettime(Process::CLOCK_MONOTONIC)
+      defined?(@now) && @now || old_clock_gettime(Process::CLOCK_MONOTONIC)
     end
     module_function :clock_gettime
 


### PR DESCRIPTION
It is considered a good practice for gems not to emit any Ruby warnings in verbose mode. For example, Rails has been following that for a while. The easiest way to catch warnings is from your tests/specs.

In this PR I have explicitly enabled Ruby verbose mode in specs and fixed most warnings.

Only 2 are remaining:

> WARNING Request#[] is deprecated and will be removed in a future version of Rack. Please use request.params[] instead

I have submitted separately: https://github.com/MiniProfiler/rack-mini-profiler/pull/386

> activesupport-3.2.22.5/lib/active_support/core_ext/enumerable.rb:58: warning: method redefined; discarding old sum

This should be fixed in >= 4.0, but it is locked at 3.x here. I feel like this update is out of scope, and can be done separately.

