### PR TITLE
Display controller name at ActionController#process

### DIFF
--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -58,7 +58,7 @@ module Rack::MiniProfilerRails
 
     # Attach to various Rails methods
     ActiveSupport.on_load(:action_controller) do
-      ::Rack::MiniProfiler.profile_method(ActionController::Base, :process) { |action| "Executing action: #{action}" }
+      ::Rack::MiniProfiler.profile_method(ActionController::Base, :process) { |action| "Executing: #{self.class.to_s}##{action}" }
     end
     ActiveSupport.on_load(:action_view) do
       ::Rack::MiniProfiler.profile_method(ActionView::Template, :render) { |x, y| "Rendering: #{@virtual_path}" }


### PR DESCRIPTION
It might be just me, but I would find it useful to see the name of the controller, not just the name of the action.