### PR TITLE
Fix: lib/mini_profiler_rails/railtie.rb:98:in `>': comparison of Integer with nil failed (ArgumentError)

### DIFF
--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -95,6 +95,7 @@ module Rack::MiniProfilerRails
       middlewares = app.middleware.middlewares
       if Rack::MiniProfiler.config.suppress_encoding.nil? &&
           middlewares.include?(Rack::Deflater) &&
+          middlewares.include?(Rack::MiniProfiler) &&
           middlewares.index(Rack::Deflater) > middlewares.index(Rack::MiniProfiler)
         Rack::MiniProfiler.config.suppress_encoding = true
       end


### PR DESCRIPTION

## How to reproduce:

#### 1. Put gem in Rails with require false. 

`gem 'rack-mini-profiler', require: false`

#### 2. Add Rack::Deflater to application.rb

```
    # 80% Smaller Rails Page Size With Rack Deflate
    # https://www.schneems.com/2017/11/08/80-smaller-rails-footprint-with-rack-deflate/
    config.middleware.insert_after ActionDispatch::Static, Rack::Deflater
```

#### 3. Conditionally require rack-mini-profiler:

```
def enable_rack_mini_profiler?
  Rails.env.development? || Rails.env.production?
end

if enable_rack_mini_profiler?
  require "rack-mini-profiler"

  # Don't use rack-mini-profiler's default storage settings in production. 
  # By default, it uses the filesystem to store data. 
  # That can be slow - it's better to just use memory.
  Rack::MiniProfiler.config.storage = Rack::MiniProfiler::MemoryStore

  # initialization is skipped so trigger it
  Rack::MiniProfilerRails.initialize!(Rails.application)

  # Custom middleware ordering (required if using Rack::Deflate with Rails)
  # ref: https://github.com/MiniProfiler/rack-mini-profiler#custom-middleware-ordering-required-if-using-rackdeflate-with-rails
  Rails.application.middleware.delete(Rack::MiniProfiler)
  Rails.application.middleware.insert_after(Rack::Deflater, Rack::MiniProfiler)
end

```

#### 4. Run assets:precompile

```
➜ rake assets:precompile
Caching: ON
/Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-mini-profiler-1.0.2/lib/mini_profiler_rails/railtie.rb:98:in `>': comparison of Integer with nil failed (ArgumentError)
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/rack-mini-profiler-1.0.2/lib/mini_profiler_rails/railtie.rb:98:in `block in <class:Railtie>'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:69:in `block in execute_hook'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:62:in `with_execution_control'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:67:in `execute_hook'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:52:in `block in run_load_hooks'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:51:in `each'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/activesupport-6.0.0/lib/active_support/lazy_load_hooks.rb:51:in `run_load_hooks'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/railties-6.0.0/lib/rails/application/finisher.rb:129:in `block in <module:Finisher>'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/railties-6.0.0/lib/rails/initializable.rb:32:in `instance_exec'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/railties-6.0.0/lib/rails/initializable.rb:32:in `run'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/railties-6.0.0/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:228:in `block in tsort_each'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:431:in `each_strongly_connected_component_from'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:349:in `block in each_strongly_connected_component'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:347:in `each'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:347:in `call'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:347:in `each_strongly_connected_component'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:226:in `tsort_each'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/2.5.0/tsort.rb:205:in `tsort_each'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/railties-6.0.0/lib/rails/initializable.rb:60:in `run_initializers'
	from /Users/me/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/railties-6.0.0/lib/rails/application.rb:363:in `initialize!'
	from /Users/me/projects/myapp/config/environment.rb:5:in `<top (required)>'

```