### PR TITLE
Escape URLs when displaying the help page

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -539,7 +539,7 @@ module Rack
 
     def make_link(postfix, env)
       link = env["PATH_INFO"] + "?" + env["QUERY_STRING"].sub("pp=help", "pp=#{postfix}")
-      "pp=<a href='#{link}'>#{postfix}</a>"
+      "pp=<a href='#{ERB::Util.html_escape(link)}'>#{postfix}</a>"
     end
 
     def help(client_settings, env)


### PR DESCRIPTION
This fixes an XSS issue that only affects browsers that don't encode
special characters in the URL (e.g. IE11).