### PR TITLE
Use for..of instead of array loop for looping `fetch` header entries

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -851,8 +851,7 @@ var MiniProfiler = (function() {
           try {
             // look for x-mini-profile-ids
             var entries = response.headers.entries();
-            for (var i = 0; i < entries.length; i++) {
-              var pair = entries[i];
+            for (var pair of entries) {
               if (pair[0] && pair[0].toLowerCase() == "x-miniprofiler-ids") {
                 var ids = pair[1].split(",");
                 fetchResults(ids);


### PR DESCRIPTION
`rack-mini-profiler` was failing to capture `fetch` requests.

The patch for `window.fetch` was using an array syntax for looping through the response header entries but, [according to the spec, `entries` is an `iterator` object](https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries). You can try this in the browser console:

```javascript
let headers = new Headers()
headers.append('somekey', 'somevalue')
let entries = headers.entries()
console.debug('Length', entries.length) // undefined
for (let entry of entries) {
  console.debug(entry)
}
```

`entries.length` is `undefined` and that loop wasn't really doing anything. I tried with latest Firefox, Chrome and Safari and got the same result, so not sure how this was working in the first place.

