### PR TITLE
Get rid of ProfilingMethods#singleton_class

### DIFF
--- a/lib/mini_profiler/profiling_methods.rb
+++ b/lib/mini_profiler/profiling_methods.rb
@@ -112,11 +112,11 @@ module Rack
       end
 
       def profile_singleton_method(klass, method, type = :profile, &blk)
-        profile_method(singleton_class(klass), method, type, &blk)
+        profile_method(klass.singleton_class, method, type, &blk)
       end
 
       def unprofile_singleton_method(klass, method)
-        unprofile_method(singleton_class(klass), method)
+        unprofile_method(klass.singleton_class, method)
       end
 
       # Add a custom timing. These are displayed similar to SQL/query time in
@@ -143,10 +143,6 @@ module Rack
       end
 
       private
-
-      def singleton_class(klass)
-        class << klass; self; end
-      end
 
       def clean_method_name(method)
         method.to_s.gsub(/[\?\!]/, "")


### PR DESCRIPTION
It was introduced in https://github.com/MiniProfiler/rack-mini-profiler/pull/190, probably with pre MRI 1.8.x support in mind.

But now rack-mini-profiler requires 2.3+ so it's no longer needed.

If it was named differently it wouldn't matter, but right now it's overriding and changing the visibility of `Object#singleton_class`.