### PR TITLE
Fix for undefined MiniProfiler.templates

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -172,7 +172,7 @@ var MiniProfiler = (function() {
               var json = JSON.parse(request.responseText);
               fetchedIds.push(id);
 
-              if (json != "hidden") {
+              if (json != "hidden" && MiniProfiler.templates) {
                 buttonShow(json);
               }
             }


### PR DESCRIPTION
When loading pages without performing a full http request (using `fetch`), this sequence is possible:

1. It makes a `POST /results` requests to collect the results of the request.
2. The middleware intercepts the page and injects `includes.js`. This reset `MiniProfiler` and loads `vendor.js` asynchronously, which will initialize `MiniProfiler.templates`. 

When (1) ends, it will try to render the results and, if that happens before (2) has loaded the templates, it will produce the mentioned error.

This patch fixes the problem. Maybe a more solid solution would be to generate a single file with current contents of `include` + `vendor`, so that `MiniProfiler` and `MiniProfiler.templates` get initialized at the same time.

Fix #414 
