### PR TITLE
Update Redis example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,7 @@ Rack::MiniProfiler.config.storage = Rack::MiniProfiler::MemoryStore
 
 # set RedisStore
 if Rails.env.production?
-  uri = URI.parse(ENV["REDIS_SERVER_URL"])
-  Rack::MiniProfiler.config.storage_options = { :host => uri.host, :port => uri.port, :password => uri.password }
+  Rack::MiniProfiler.config.storage_options = { url: ENV["REDIS_SERVER_URL"] }
   Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
 end
 ```


### PR DESCRIPTION
If you're using TLS to secure your Redis connection, the given example
will not work correctly because it will choose the incorrect protocol.
You can pass a URL directly to Redis instead of parsing it yourself,
and this gives you the ability to switch between plaintext and TLS with
a single config update.