### PR TITLE
Allow Mini Profiler patches to be optional in Rails applications

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,11 +16,6 @@ Style/AndOr:
 Style/FrozenStringLiteralComment:
   Enabled: true
 
-# Do not use braces for hash literals when they are the last argument of a
-# method call.
-Style/BracesAroundHashParameters:
-  Enabled: true
-
 # Align `when` with `case`.
 Layout/CaseIndentation:
   Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,9 @@ task default: [:rubocop, :spec]
 require 'rspec/core'
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
-  spec.pattern = FileList['spec/**/*_spec.rb']
+  pattern = ARGV[1] || 'spec/**/*_spec.rb'
+  spec.pattern = FileList[pattern]
+  spec.verbose = false
 end
 
 desc "builds a gem"

--- a/lib/disable_method_patches.rb
+++ b/lib/disable_method_patches.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Rack
+  class MiniProfiler
+    DISABLE_METHOD_PATCHES = true
+  end
+end

--- a/lib/enable_rails_patches.rb
+++ b/lib/enable_rails_patches.rb
@@ -2,6 +2,6 @@
 
 module Rack
   class MiniProfiler
-    DISABLE_METHOD_PATCHES = true
+    ENABLE_RAILS_PATCHES = true
   end
 end

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -6,6 +6,10 @@ module Rack
 
       include Rack::MiniProfiler::ProfilingMethods
 
+      def disable_method_patches?
+        !!defined?(::Rack::MiniProfiler::DISABLE_METHOD_PATCHES)
+      end
+
       def generate_id
         rand(36**20).to_s(36)
       end

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -67,6 +67,17 @@ module Rack
           This feature is disabled by default, to enable set the enable_advanced_debugging_tools option to true in Mini Profiler config.
         TEXT
       end
+
+      def binds_to_params(binds)
+        return if binds.nil? || config.max_sql_param_length == 0
+        # map ActiveRecord::Relation::QueryAttribute to [name, value]
+        params = binds.map { |c| c.kind_of?(Array) ? [c.first, c.last] : [c.name, c.value] }
+        if (skip = config.skip_sql_param_names)
+          params.map { |(n, v)| n =~ skip ? [n, nil] : [n, v] }
+        else
+          params
+        end
+      end
     end
 
     #

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -5,9 +5,10 @@ module Rack
     class << self
 
       include Rack::MiniProfiler::ProfilingMethods
+      attr_accessor :subscribe_sql_active_record
 
-      def disable_method_patches?
-        !!defined?(::Rack::MiniProfiler::DISABLE_METHOD_PATCHES)
+      def patch_rails?
+        !!defined?(::Rack::MiniProfiler::ENABLE_RAILS_PATCHES)
       end
 
       def generate_id

--- a/lib/mini_profiler/timer_struct/custom.rb
+++ b/lib/mini_profiler/timer_struct/custom.rb
@@ -6,6 +6,7 @@ module Rack
       # Timing system for a custom timers such as cache, redis, RPC, external API
       # calls, etc.
       class Custom < TimerStruct::Base
+        attr_accessor :parent
         def initialize(type, duration_ms, page, parent)
           @parent      = parent
           @page        = page

--- a/lib/mini_profiler/timer_struct/request.rb
+++ b/lib/mini_profiler/timer_struct/request.rb
@@ -11,7 +11,7 @@ module Rack
           end
         end
 
-        attr_accessor :children_duration
+        attr_accessor :children_duration, :start, :parent
 
         def initialize(name, page, parent)
           start_millis = (Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1000).to_i - page[:started]
@@ -62,10 +62,6 @@ module Rack
           self[:start_milliseconds]
         end
 
-        def start
-          @start
-        end
-
         def depth
           self[:depth]
         end
@@ -91,6 +87,20 @@ module Rack
           end
         end
 
+        def move_child(child, destination)
+          if index = self[:children].index(child)
+            self[:children].slice!(index)
+            self[:has_children] = self[:children].size > 0
+
+            destination[:children].push(child)
+            destination[:has_children] = true
+
+            child[:parent_timing_id] = destination[:id]
+            child.parent = destination
+            child.adjust_depth
+          end
+        end
+
         def add_sql(query, elapsed_ms, page, params = nil, skip_backtrace = false, full_backtrace = false)
           TimerStruct::Sql.new(query, elapsed_ms, page, self, params, skip_backtrace, full_backtrace).tap do |timer|
             self[:sql_timings].push(timer)
@@ -99,6 +109,19 @@ module Rack
             self[:sql_timings_duration_milliseconds] += elapsed_ms
             page[:duration_milliseconds_in_sql]      += elapsed_ms
             page[:sql_count] += 1
+          end
+        end
+
+        def move_sql(sql, destination)
+          if index = self[:sql_timings].index(sql)
+            self[:sql_timings].slice!(index)
+            self[:has_sql_timings] = self[:sql_timings].size > 0
+            self[:sql_timings_duration_milliseconds] -= sql[:duration_milliseconds]
+            destination[:sql_timings].push(sql)
+            destination[:has_sql_timings] = true
+            destination[:sql_timings_duration_milliseconds] += sql[:duration_milliseconds]
+            sql[:parent_timing_id] = destination[:id]
+            sql.parent = destination
           end
         end
 
@@ -119,18 +142,37 @@ module Rack
           end
         end
 
+        def move_custom(type, custom, destination)
+          if index = self[:custom_timings][type]&.index(custom)
+            custom[:parent_timing_id] = destination[:id]
+            custom.parent = destination
+            self[:custom_timings][type].slice!(index)
+            if self[:custom_timings][type].size == 0
+              self[:custom_timings].delete(type)
+              self[:custom_timing_stats].delete(type)
+            else
+              self[:custom_timing_stats][type][:count] -= 1
+              self[:custom_timing_stats][type][:duration] -= custom[:duration_milliseconds]
+            end
+            destination[:custom_timings][type] ||= []
+            destination[:custom_timings][type].push(custom)
+            destination[:custom_timing_stats][type] ||= { count: 0, duration: 0.0 }
+            destination[:custom_timing_stats][type][:count] += 1
+            destination[:custom_timing_stats][type][:duration] += custom[:duration_milliseconds]
+          end
+        end
+
         def record_time(milliseconds = nil)
           milliseconds ||= (Process.clock_gettime(Process::CLOCK_MONOTONIC) - @start) * 1000
           self[:duration_milliseconds]                  = milliseconds
           self[:is_trivial]                             = true if milliseconds < self[:trivial_duration_threshold_milliseconds]
-          self[:duration_without_children_milliseconds] = milliseconds - @children_duration
-
-          if @parent
-            @parent.children_duration += milliseconds
-          end
-
+          self[:duration_without_children_milliseconds] = milliseconds - self[:children].sum(&:duration_ms)
         end
 
+        def adjust_depth
+          self[:depth] = self.parent ? self.parent[:depth] + 1 : 0
+          self[:children].each(&:adjust_depth)
+        end
       end
     end
   end

--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -6,6 +6,8 @@ module Rack
     # Timing system for a SQL query
     module TimerStruct
       class Sql < TimerStruct::Base
+        attr_accessor :parent
+
         def initialize(query, duration_ms, page, parent, params = nil, skip_backtrace = false, full_backtrace = false)
 
           stack_trace = nil

--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -91,11 +91,11 @@ module Rack::MiniProfilerRails
       end
 
       subscribe("render_partial.action_view") do |name, start, finish, id, payload|
-        render_notification_handler(payload[:identifier].split("/").last(2).join("/"), finish, start)
+        render_notification_handler(shorten_identifier(payload[:identifier]), finish, start)
       end
 
       subscribe("render_template.action_view") do |name, start, finish, id, payload|
-        render_notification_handler(payload[:layout], finish, start)
+        render_notification_handler(shorten_identifier(payload[:identifier]), finish, start)
       end
 
       if Rack::MiniProfiler.subscribe_sql_active_record
@@ -128,6 +128,10 @@ module Rack::MiniProfilerRails
 
   def self.get_key(payload)
     "mini_profiler_parent_timer_#{payload[:controller]}_#{payload[:action]}".to_sym
+  end
+
+  def self.shorten_identifier(identifier)
+    identifier.split('/').last(2).join('/')
   end
 
   def self.serves_static_assets?(app)

--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -116,11 +116,11 @@ module Rack::MiniProfilerRails
     @already_initialized = true
   end
 
-  def self.subscribe(name, &blk)
+  def self.subscribe(event, &blk)
     if ActiveSupport::Notifications.respond_to?(:monotonic_subscribe)
-      ActiveSupport::Notifications.monotonic_subscribe(name) { |*args| blk.call(*args) }
+      ActiveSupport::Notifications.monotonic_subscribe(event) { |*args| blk.call(*args) }
     else
-      ActiveSupport::Notifications.subscribe(name) do |name, start, finish, id, payload|
+      ActiveSupport::Notifications.subscribe(event) do |name, start, finish, id, payload|
         blk.call(name, start.to_f, finish.to_f, id, payload)
       end
     end

--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -57,7 +57,7 @@ module Rack::MiniProfilerRails
     app.middleware.insert(0, Rack::MiniProfiler)
     c.enable_advanced_debugging_tools = Rails.env.development?
 
-    if !::Rails.configuration.respond_to?(:mini_profiler_without_patches) || !::Rails.configuration.mini_profiler_without_patches
+    if !::Rack::MiniProfiler.disable_method_patches?
       # Attach to various Rails methods
       ActiveSupport.on_load(:action_controller) do
         ::Rack::MiniProfiler.profile_method(ActionController::Base, :process) { |action| "Executing action: #{action}" }

--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -117,7 +117,13 @@ module Rack::MiniProfilerRails
   end
 
   def self.subscribe(name, &blk)
-    ActiveSupport::Notifications.monotonic_subscribe(name) { |*args| blk.call(*args) }
+    if ActiveSupport::Notifications.respond_to?(:monotonic_subscribe)
+      ActiveSupport::Notifications.monotonic_subscribe(name) { |*args| blk.call(*args) }
+    else
+      ActiveSupport::Notifications.subscribe(name) do |name, start, finish, id, payload|
+        blk.call(name, start.to_f, finish.to_f, id, payload)
+      end
+    end
   end
 
   def self.get_key(payload)

--- a/lib/mini_profiler_rails/railtie_methods.rb
+++ b/lib/mini_profiler_rails/railtie_methods.rb
@@ -22,7 +22,7 @@ module Rack::MiniProfilerRailsMethods
         children_duration += child[:duration_milliseconds]
       end
     end
-    node[:duration_without_children_milliseconds] = duration - children_duration
+    node[:duration_without_children_milliseconds] = duration_ms - children_duration
     to_be_moved[:requests].each { |req| current.move_child(req, node) }
 
     current.sql_timings.each do |sql|

--- a/lib/mini_profiler_rails/railtie_methods.rb
+++ b/lib/mini_profiler_rails/railtie_methods.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Rack::MiniProfilerRailsMethods
+  def render_notification_handler(name, finish, start, name_as_description: false)
+    return if !should_measure?
+
+    description = name_as_description ? name : "Rendering: #{name}"
+    current = Rack::MiniProfiler.current.current_timer
+    node = current.add_child(description)
+    duration = finish - start
+    duration_ms = duration * 1000
+    node.start -= duration
+    node[:start_milliseconds] -= duration_ms
+    node.record_time(duration_ms)
+
+    children_duration = 0
+    to_be_moved = { requests: [], sql: [], custom: {} }
+    current.children.each do |child|
+      next if child == node
+      if should_move?(child, node)
+        to_be_moved[:requests] << child
+        children_duration += child[:duration_milliseconds]
+      end
+    end
+    node[:duration_without_children_milliseconds] = duration - children_duration
+    to_be_moved[:requests].each { |req| current.move_child(req, node) }
+
+    current.sql_timings.each do |sql|
+      to_be_moved[:sql] << sql if should_move?(sql, node)
+    end
+    to_be_moved[:sql].each { |sql| current.move_sql(sql, node) }
+
+    current.custom_timings.each do |type, timings|
+      to_be_moved[:custom] = []
+      timings.each do |custom|
+        to_be_moved[:custom] << custom if should_move?(custom, node)
+      end
+      to_be_moved[:custom].each { |custom| current.move_custom(type, custom, node) }
+    end
+  end
+
+  def should_measure?
+    current = Rack::MiniProfiler.current
+    current && current.measure
+  end
+
+  def should_move?(child, node)
+    start = :start_milliseconds
+    duration = :duration_milliseconds
+    child[start] >= node[start] &&
+    child[start] + child[duration] <= node[start] + node[duration]
+  end
+
+  extend self
+end

--- a/lib/patches/db/activerecord.rb
+++ b/lib/patches/db/activerecord.rb
@@ -15,17 +15,6 @@ module Rack
         end
       end
 
-      def binds_to_params(binds)
-        return if binds.nil? || Rack::MiniProfiler.config.max_sql_param_length == 0
-        # map ActiveRecord::Relation::QueryAttribute to [name, value]
-        params = binds.map { |c| c.kind_of?(Array) ? [c.first, c.last] : [c.name, c.value] }
-        if (skip = Rack::MiniProfiler.config.skip_sql_param_names)
-          params.map { |(n, v)| n =~ skip ? [n, nil] : [n, v] }
-        else
-          params
-        end
-      end
-
       def log_with_miniprofiler(*args, &block)
         return log_without_miniprofiler(*args, &block) unless SqlPatches.should_measure?
 
@@ -37,7 +26,7 @@ module Rack
         return rval if Rack::MiniProfiler.config.skip_schema_queries && name =~ (/SCHEMA/)
 
         elapsed_time = SqlPatches.elapsed_time(start)
-        Rack::MiniProfiler.record_sql(sql, elapsed_time, binds_to_params(binds))
+        Rack::MiniProfiler.record_sql(sql, elapsed_time, Rack::MiniProfiler.binds_to_params(binds))
         rval
       end
     end

--- a/lib/rack-mini-profiler.rb
+++ b/lib/rack-mini-profiler.rb
@@ -27,11 +27,8 @@ require 'mini_profiler/context'
 require 'mini_profiler/client_settings'
 require 'mini_profiler/gc_profiler'
 require 'mini_profiler/profiler'
-
-if !::Rack::MiniProfiler.disable_method_patches?
-  require 'patches/sql_patches'
-  require 'patches/net_patches'
-end
+require 'patches/sql_patches'
+require 'patches/net_patches'
 
 if defined?(::Rails) && defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i >= 3
   require 'mini_profiler_rails/railtie'

--- a/lib/rack-mini-profiler.rb
+++ b/lib/rack-mini-profiler.rb
@@ -28,9 +28,13 @@ require 'mini_profiler/client_settings'
 require 'mini_profiler/gc_profiler'
 require 'mini_profiler/profiler'
 
-require 'patches/sql_patches'
-require 'patches/net_patches'
-
 if defined?(::Rails) && defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i >= 3
   require 'mini_profiler_rails/railtie'
+  if !::Rails.configuration.respond_to?(:mini_profiler_without_patches) || !::Rails.configuration.mini_profiler_without_patches
+    require 'patches/sql_patches'
+    require 'patches/net_patches'
+  end
+else
+  require 'patches/sql_patches'
+  require 'patches/net_patches'
 end

--- a/lib/rack-mini-profiler.rb
+++ b/lib/rack-mini-profiler.rb
@@ -28,13 +28,11 @@ require 'mini_profiler/client_settings'
 require 'mini_profiler/gc_profiler'
 require 'mini_profiler/profiler'
 
-if defined?(::Rails) && defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i >= 3
-  require 'mini_profiler_rails/railtie'
-  if !::Rails.configuration.respond_to?(:mini_profiler_without_patches) || !::Rails.configuration.mini_profiler_without_patches
-    require 'patches/sql_patches'
-    require 'patches/net_patches'
-  end
-else
+if !::Rack::MiniProfiler.disable_method_patches?
   require 'patches/sql_patches'
   require 'patches/net_patches'
+end
+
+if defined?(::Rails) && defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i >= 3
+  require 'mini_profiler_rails/railtie'
 end

--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'mini_racer'
   s.add_development_dependency 'nokogiri'
+  s.add_development_dependency 'rubocop-discourse'
 
   s.require_paths = ["lib"]
 end

--- a/spec/integration/railtie_methods_spec.rb
+++ b/spec/integration/railtie_methods_spec.rb
@@ -112,6 +112,29 @@ describe Rack::MiniProfilerRailsMethods do
       end
     end
 
+    it 'should correct the duration_milliseconds and duration_without_children_milliseconds attributes for the nodes' do
+      dm = :duration_milliseconds
+      dwcm = :duration_without_children_milliseconds
+
+      expect(@nodes[:A][dm].round).to eq(80)
+      expect(@nodes[:A][dwcm].round).to eq(80 - (15 + 30 + 10))
+
+      expect(@nodes[:B][dm].round).to eq(15)
+      expect(@nodes[:B][dwcm].round).to eq(15)
+
+      expect(@nodes[:C][dm].round).to eq(30)
+      expect(@nodes[:C][dwcm].round).to eq(30 - 10)
+
+      expect(@nodes[:D][dm].round).to eq(10)
+      expect(@nodes[:D][dwcm].round).to eq(10)
+
+      expect(@nodes[:E][dm].round).to eq(10)
+      expect(@nodes[:E][dwcm].round).to eq(10)
+
+      expect(@nodes[:F][dm].round).to eq(10)
+      expect(@nodes[:F][dwcm].round).to eq(10)
+    end
+
     it 'should move sql timings to the correct nodes' do
       %i{A B E F}.each do |name|
         sql_timings = @nodes[name].sql_timings

--- a/spec/integration/railtie_methods_spec.rb
+++ b/spec/integration/railtie_methods_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'rack/test'
+require File.expand_path('../../../lib/mini_profiler_rails/railtie_methods', __FILE__)
+
+def to_seconds(array)
+  array.map! { |n, s, f| [n, s / 1000.0, f / 1000.0] }
+  array
+end
+
+describe Rack::MiniProfilerRailsMethods do
+  describe '#render_notification_handler' do
+    before do
+      allow(Process).to receive(:clock_gettime).and_return(0)
+      Rack::MiniProfiler.create_current
+      @current_timer = Rack::MiniProfiler.current.current_timer
+
+      # SQL timings
+      to_seconds([
+        ['SELECT A', 2,   04], # in node A
+        ['SELECT B', 6,   15], # in node B
+        ['SELECT E', 73,  77], # in node E
+        ['SELECT F', 93,  96]  # in node F
+      ]).each do |query, start, finish|
+        allow(Process).to receive(:clock_gettime).and_return(finish)
+        @current_timer.add_sql(
+          query,
+          finish - start,
+          Rack::MiniProfiler.current.page_struct
+        )
+      end
+
+      # Custom timings
+      to_seconds([
+        ['custom1 D', 53, 55],
+        ['custom1 D', 57, 60],
+        ['custom2 D', 55, 57],
+        ['custom1 F', 90, 99],
+        ['custom1 B', 11, 16],
+        ['custom1 B', 17, 19]
+      ]).each do |type, start, finish|
+        allow(Process).to receive(:clock_gettime).and_return(finish)
+        timing = @current_timer.add_custom(
+          type,
+          finish - start,
+          Rack::MiniProfiler.current.page_struct
+        )
+        @custom_timings ||= {}
+        @custom_timings[type] ||= []
+        @custom_timings[type] << timing
+      end
+
+      # Request nodes that are created when rails fires an ActiveSupport
+      # notification when a template is done rendering.
+      # Templates are usually nested, so we attempt to rearrange the nodes
+      # so that they're nested in the same way as the templates they represent.
+
+      # The order of the nodes here is the same order of the AS notifications
+      # we get for them when they're done rendering.
+      # B finishes first, F finishes last
+
+      # [name, start, finish] units are ms which are converted by `to_seconds` to seconds
+      to_seconds([
+        ['B',  5,     20],
+        ['D',  50,    60],
+        ['C',  40,    70],
+        ['E',  70,    80],
+        ['A',  0,     80],
+        ['F',  90,    100]
+      ]).each do |name, start, finish|
+        allow(Process).to receive(:clock_gettime).and_return(finish)
+        described_class.render_notification_handler(name, finish, start, name_as_description: true)
+      end
+      @nodes = {
+        A: @current_timer.children[0],
+        F: @current_timer.children[1]
+      }
+      @nodes.merge!(
+        B: @nodes[:A].children[0],
+        C: @nodes[:A].children[1],
+        E: @nodes[:A].children[2]
+      )
+      @nodes.merge!(
+        D: @nodes[:C].children[0]
+      )
+
+      # This is how the nodes should be nested after they do through
+      # render_notification_handler:
+      #  ['A', 0, 80],
+      #      ['B', 5, 20],
+      #      ['C', 40, 70],
+      #          ['D', 50, 60],
+      #      ['E', 70, 80],
+      #  ['F', 90, 100]
+      # A is parent for B, C and E
+      # C is parent for D
+      # A and F are siblings
+    end
+
+    it 'should be able to nest the nodes correctly' do
+      @nodes.each do |key, node|
+        expect(key.to_s).to eq(node.name)
+      end
+      top_nodes = @current_timer.children
+      expect(top_nodes.map(&:name)).to eq(%w{A F})
+      expect(@nodes[:A].children.map(&:name)).to eq(%w{B C E})
+      expect(@nodes[:C].children.map(&:name)).to eq(%w{D})
+
+      without_children = %i{B D E F}
+      without_children.each do |name|
+        expect(@nodes[name].children).to eq([])
+      end
+    end
+
+    it 'should move sql timings to the correct nodes' do
+      %i{A B E F}.each do |name|
+        sql_timings = @nodes[name].sql_timings
+        expect(sql_timings.size).to eq(1)
+        expect(sql_timings[0][:formatted_command_string]).to eq("SELECT #{name}")
+      end
+      expect(@current_timer.sql_timings).to eq([])
+    end
+
+    it 'should move custom timings to the correct nodes' do
+      ct = :custom_timings
+      cts = :custom_timing_stats
+
+      expect(@nodes[:D][ct].size).to eq(2)
+      expect(@nodes[:D][cts].size).to eq(2)
+      expect(@nodes[:D][ct]['custom1 D'].size).to eq(2)
+      expect(@nodes[:D][ct]['custom1 D']).to eq(@custom_timings['custom1 D'])
+      expect(@nodes[:D][cts]['custom1 D'][:count]).to eq(2)
+      expect((@nodes[:D][cts]['custom1 D'][:duration] * 1000).round).to eq(2 + 3)
+
+      expect(@nodes[:D][ct]['custom2 D'].size).to eq(1)
+      expect(@nodes[:D][ct]['custom2 D']).to eq(@custom_timings['custom2 D'])
+      expect(@nodes[:D][cts]['custom2 D'][:count]).to eq(1)
+      expect((@nodes[:D][cts]['custom2 D'][:duration] * 1000).round).to eq(2)
+
+      expect(@nodes[:F][ct].size).to eq(1)
+      expect(@nodes[:F][cts].size).to eq(1)
+      expect(@nodes[:F][ct]['custom1 F'].size).to eq(1)
+      expect(@nodes[:F][ct]['custom1 F']).to eq(@custom_timings['custom1 F'])
+      expect(@nodes[:F][cts]['custom1 F'][:count]).to eq(1)
+      expect((@nodes[:F][cts]['custom1 F'][:duration] * 1000).round).to eq(9)
+
+      expect(@nodes[:B][ct].size).to eq(1)
+      expect(@nodes[:B][cts].size).to eq(1)
+      expect(@nodes[:B][ct]['custom1 B'].size).to eq(2)
+      expect(@nodes[:B][ct]['custom1 B']).to eq(@custom_timings['custom1 B'])
+      expect(@nodes[:B][cts]['custom1 B'][:count]).to eq(2)
+      expect((@nodes[:B][cts]['custom1 B'][:duration] * 1000).round).to eq(5 + 2)
+
+      expect(@current_timer[ct]).to eq({})
+      expect(@current_timer[cts]).to eq({})
+    end
+  end
+end

--- a/spec/lib/sql_patches_spec.rb
+++ b/spec/lib/sql_patches_spec.rb
@@ -32,6 +32,8 @@ describe SqlPatches do
 
     it "uses detection of env variable is not defined" do
       with_patch_env(nil) do
+        expect(SqlPatches.all_patch_files).to eq([])
+        expect(Rack::MiniProfiler).to receive(:patch_rails?) { true }
         expect(SqlPatches.all_patch_files).to eq(["activerecord"])
       end
     end

--- a/spec/lib/timer_struct/request_timer_struct_spec.rb
+++ b/spec/lib/timer_struct/request_timer_struct_spec.rb
@@ -294,8 +294,8 @@ describe Rack::MiniProfiler::TimerStruct::Request do
     it 'updates custom_timings and custom_timing_stats attributes' do
       expect(@origin[:custom_timings]).to eq({})
       expect(@origin[:custom_timing_stats]).to eq({})
-      expect(@destination[:custom_timings]).to eq({ 'tests' => [@custom] })
-      expect(@destination[:custom_timing_stats]).to eq({ 'tests' => { count: 1, duration: 30 } })
+      expect(@destination[:custom_timings]).to eq('tests' => [@custom])
+      expect(@destination[:custom_timing_stats]).to eq('tests' => { count: 1, duration: 30 })
     end
   end
 
@@ -309,10 +309,10 @@ describe Rack::MiniProfiler::TimerStruct::Request do
     end
 
     it 'updates custom_timings and custom_timing_stats attributes' do
-      expect(@origin[:custom_timings]).to eq({ 'tests' => [@custom_2] })
-      expect(@origin[:custom_timing_stats]).to eq({ 'tests' => { count: 1, duration: 50 } })
-      expect(@destination[:custom_timings]).to eq({ 'tests' => [@custom] })
-      expect(@destination[:custom_timing_stats]).to eq({ 'tests' => { count: 1, duration: 30 } })
+      expect(@origin[:custom_timings]).to eq('tests' => [@custom_2])
+      expect(@origin[:custom_timing_stats]).to eq('tests' => { count: 1, duration: 50 })
+      expect(@destination[:custom_timings]).to eq('tests' => [@custom])
+      expect(@destination[:custom_timing_stats]).to eq('tests' => { count: 1, duration: 30 })
     end
   end
 
@@ -328,8 +328,8 @@ describe Rack::MiniProfiler::TimerStruct::Request do
     it 'updates custom_timings and custom_timing_stats attributes' do
       expect(@origin[:custom_timings]).to eq({})
       expect(@origin[:custom_timing_stats]).to eq({})
-      expect(@destination[:custom_timings]).to eq({ 'tests' => [@custom_2, @custom] })
-      expect(@destination[:custom_timing_stats]).to eq({ 'tests' => { count: 2, duration: 80 } })
+      expect(@destination[:custom_timings]).to eq('tests' => [@custom_2, @custom])
+      expect(@destination[:custom_timing_stats]).to eq('tests' => { count: 2, duration: 80 })
     end
   end
 

--- a/spec/lib/timer_struct/request_timer_struct_spec.rb
+++ b/spec/lib/timer_struct/request_timer_struct_spec.rb
@@ -6,6 +6,10 @@ describe Rack::MiniProfiler::TimerStruct::Request do
     Rack::MiniProfiler::TimerStruct::Page.new({})
   end
 
+  def origin_and_destination(req)
+    [req.add_child('origin'), req.add_child('destination')]
+  end
+
   before do
     @name = 'cool request'
     @request = Rack::MiniProfiler::TimerStruct::Request.createRoot(@name, new_page)
@@ -24,7 +28,7 @@ describe Rack::MiniProfiler::TimerStruct::Request do
   end
 
   it 'begins with a children duration of 0' do
-    expect(@request.children_duration).to eq(0)
+    expect(@request.children.sum(&:duration_ms)).to eq(0)
   end
 
   it 'has a false HasChildren attribute' do
@@ -125,7 +129,7 @@ describe Rack::MiniProfiler::TimerStruct::Request do
       end
 
       it 'increases the children duration' do
-        expect(@request.children_duration).to eq(1111)
+        expect(@request.children.sum(&:duration_ms)).to eq(1111)
       end
 
       it 'marks short timings as trivial' do
@@ -150,6 +154,216 @@ describe Rack::MiniProfiler::TimerStruct::Request do
           expect(@request[:duration_without_children_milliseconds]).to eq(123)
         end
 
+      end
+    end
+  end
+
+  describe '#move_child' do
+    before do
+      @origin, @destination = origin_and_destination(@request)
+      @child = @origin.add_child('child')
+      @origin.move_child(@child, @destination)
+    end
+
+    it 'updates children attribute' do
+      expect(@origin.children).to eq([])
+      expect(@destination.children).to eq([@child])
+    end
+
+    it 'updates has_children attribute' do
+      expect(@origin[:has_children]).to eq(false)
+      expect(@destination[:has_children]).to eq(true)
+    end
+
+    it 'updates parent_timing_id attribute' do
+      expect(@child[:parent_timing_id]).to eq(@destination[:id])
+    end
+
+    it 'updates parent attribute' do
+      expect(@child.parent).to eq(@destination)
+    end
+  end
+
+  context 'when moving to different depth' do
+    describe '#move_child' do
+      before do
+        @origin = @request.add_child('origin')
+        @destination_parent = @request.add_child('destination_parent')
+        @destination = @destination_parent.add_child('destination')
+        @child = @origin.add_child('child')
+        @origin.move_child(@child, @destination)
+      end
+
+      it 'updates depth correctly' do
+        expect(@child[:depth]).to eq(@destination[:depth] + 1)
+        expect(@destination[:depth]).to eq(@destination_parent[:depth] + 1)
+        expect(@destination_parent[:depth]).to eq(@origin[:depth])
+      end
+    end
+  end
+
+  describe '#move_sql' do
+    before do
+      @page = new_page
+      @origin, @destination = origin_and_destination(@request)
+      @sql = @origin.add_sql('SELECT 1;', 30, @page)
+      @origin.move_sql(@sql, @destination)
+    end
+
+    it 'updates sql_timings_duration_milliseconds attribute' do
+      expect(@origin[:sql_timings_duration_milliseconds]).to eq(0)
+      expect(@destination[:sql_timings_duration_milliseconds]).to eq(30)
+    end
+
+    it 'updates parent_timing_id and parent attributes' do
+      expect(@sql[:parent_timing_id]).to eq(@destination[:id])
+      expect(@sql.parent).to eq(@destination)
+    end
+
+    it "doesn't increase duration_milliseconds_in_sql and sql_count attributes of the page" do
+      expect(@page[:duration_milliseconds_in_sql]).to eq(30)
+      expect(@page[:sql_count]).to eq(1)
+    end
+  end
+
+  context 'when origin has one sql' do
+    describe '#move_sql' do
+      before do
+        @page = new_page
+        @origin, @destination = origin_and_destination(@request)
+        @sql = @origin.add_sql('SELECT 1;', 30, @page)
+        @origin.move_sql(@sql, @destination)
+      end
+
+      it 'updates sql_timings attribute' do
+        expect(@origin[:sql_timings]).to eq([])
+        expect(@destination[:sql_timings]).to eq([@sql])
+      end
+
+      it 'updates has_sql_timings attribute' do
+        expect(@origin[:has_sql_timings]).to eq(false)
+        expect(@destination[:has_sql_timings]).to eq(true)
+      end
+    end
+  end
+
+  context 'when origin has more than one sql' do
+    describe '#move_sql' do
+      before do
+        @page = new_page
+        @origin, @destination = origin_and_destination(@request)
+        @sql = @origin.add_sql('SELECT 1;', 30, @page)
+        @sql_2 = @origin.add_sql('SELECT 2;', 40, @page)
+        @origin.move_sql(@sql, @destination)
+      end
+
+      it 'updates sql_timings attribute' do
+        expect(@origin[:sql_timings]).to eq([@sql_2])
+        expect(@destination[:sql_timings]).to eq([@sql])
+      end
+
+      it 'updates has_sql_timings attribute' do
+        expect(@origin[:has_sql_timings]).to eq(true)
+        expect(@destination[:has_sql_timings]).to eq(true)
+      end
+    end
+  end
+
+  describe '#move_custom' do
+    before do
+      @page = new_page
+      @origin, @destination = origin_and_destination(@request)
+      @custom = @origin.add_custom('tests', 30, @page)
+      @origin.move_custom('tests', @custom, @destination)
+    end
+
+    it 'updates parent_timing_id and parent attributes' do
+      expect(@custom[:parent_timing_id]).to eq(@destination[:id])
+      expect(@custom.parent).to eq(@destination)
+    end
+  end
+
+  context 'when origin has one custom timings of the type' do
+    before do
+      @page = new_page
+      @origin, @destination = origin_and_destination(@request)
+      @custom = @origin.add_custom('tests', 30, @page)
+      @origin.move_custom('tests', @custom, @destination)
+    end
+
+    it 'updates custom_timings and custom_timing_stats attributes' do
+      expect(@origin[:custom_timings]).to eq({})
+      expect(@origin[:custom_timing_stats]).to eq({})
+      expect(@destination[:custom_timings]).to eq({ 'tests' => [@custom] })
+      expect(@destination[:custom_timing_stats]).to eq({ 'tests' => { count: 1, duration: 30 } })
+    end
+  end
+
+  context 'when origin has more than one custom timings of the same type' do
+    before do
+      @page = new_page
+      @origin, @destination = origin_and_destination(@request)
+      @custom = @origin.add_custom('tests', 30, @page)
+      @custom_2 = @origin.add_custom('tests', 50, @page)
+      @origin.move_custom('tests', @custom, @destination)
+    end
+
+    it 'updates custom_timings and custom_timing_stats attributes' do
+      expect(@origin[:custom_timings]).to eq({ 'tests' => [@custom_2] })
+      expect(@origin[:custom_timing_stats]).to eq({ 'tests' => { count: 1, duration: 50 } })
+      expect(@destination[:custom_timings]).to eq({ 'tests' => [@custom] })
+      expect(@destination[:custom_timing_stats]).to eq({ 'tests' => { count: 1, duration: 30 } })
+    end
+  end
+
+  context 'when destination has more than one custom timings of the same type' do
+    before do
+      @page = new_page
+      @origin, @destination = origin_and_destination(@request)
+      @custom = @origin.add_custom('tests', 30, @page)
+      @custom_2 = @destination.add_custom('tests', 50, @page)
+      @origin.move_custom('tests', @custom, @destination)
+    end
+
+    it 'updates custom_timings and custom_timing_stats attributes' do
+      expect(@origin[:custom_timings]).to eq({})
+      expect(@origin[:custom_timing_stats]).to eq({})
+      expect(@destination[:custom_timings]).to eq({ 'tests' => [@custom_2, @custom] })
+      expect(@destination[:custom_timing_stats]).to eq({ 'tests' => { count: 2, duration: 80 } })
+    end
+  end
+
+  context 'when there is parent' do
+    describe '#adjust_depth' do
+      before do
+        @level_1 = @request.add_child('level 1')
+        @level_2 = @level_1.add_child('level 2')
+        @moved = @level_1.add_child('moved')
+        2.times { |n| @moved.add_child("child #{n}") }
+        @moved.parent = @level_2
+        @moved.adjust_depth
+      end
+
+      it 'corrects the depth of the moved node and all its children' do
+        expect(@level_2[:depth]).to eq(@level_1[:depth] + 1)
+        expect(@moved[:depth]).to eq(@level_2[:depth] + 1)
+        @moved.children.each { |child| expect(child[:depth]).to eq(@moved[:depth] + 1) }
+      end
+    end
+  end
+
+  context 'when there is no parent' do
+    describe '#adjust_depth' do
+      before do
+        @moved = @request.add_child('moved')
+        2.times { |n| @moved.add_child("child #{n}") }
+        @moved.parent = nil
+        @moved.adjust_depth
+      end
+
+      it 'sets depth to 0 and corrects children depth' do
+        expect(@moved[:depth]).to eq(0)
+        @moved.children.each { |child| expect(child[:depth]).to eq(1) }
       end
     end
   end


### PR DESCRIPTION
This PR allows Rails application to use mini profiler without any of the monkey patches that mini profiler ships with, instead mini profiler will rely completely on [`ActiveSupport::Notifications`](https://edgeguides.rubyonrails.org/active_support_instrumentation.html#subscribing-to-an-event). 

To use the non-patches version in your Rails app, add `config.mini_profiler_without_patches = true` to your environment configurations file(s).

There will be some differences between the patches and no-patches versions, for example most importantly measuring SQL/actions/render time won't be as accurate, and there won't be a `Net::HTTP` "step" because there is no official API that we can use to replicate what this patch does https://github.com/MiniProfiler/rack-mini-profiler/blob/master/lib/patches/net_patches.rb.