### PR TITLE
adding rubocop-discourse and fixing Style/RedundantReturn offenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,6 @@ gem 'codecov', require: false, group: :test
 group :development do
   gem 'guard', platforms: [:mri_22, :mri_23]
   gem 'guard-rspec', platforms: [:mri_22, :mri_23]
+  gem 'rubocop', require: false
+  gem 'rubocop-discourse', require: false
 end

--- a/lib/mini_profiler/gc_profiler.rb
+++ b/lib/mini_profiler/gc_profiler.rb
@@ -151,7 +151,7 @@ String stats:
       body << "#{count} : #{string}\n"
     end
 
-    return [200, { 'Content-Type' => 'text/plain' }, body]
+    [200, { 'Content-Type' => 'text/plain' }, body]
   ensure
     prev_gc_state ? GC.disable : GC.enable
   end

--- a/lib/patches/db/mongo.rb
+++ b/lib/patches/db/mongo.rb
@@ -8,7 +8,7 @@ class Mongo::Server::Connection
     result, _record = SqlPatches.record_sql(args[0][0].payload.inspect) do
       dispatch_without_timing(*args, &blk)
     end
-    return result
+    result
   end
 
   # TODO: change to Module#prepend as soon as Ruby 1.9.3 support is dropped

--- a/lib/patches/db/moped.rb
+++ b/lib/patches/db/moped.rb
@@ -9,6 +9,6 @@ class Moped::Node
     result, _record = SqlPatches.record_sql(args[0].log_inspect) do
       process_without_profiling(*args, &blk)
     end
-    return result
+    result
   end
 end

--- a/lib/patches/db/plucky.rb
+++ b/lib/patches/db/plucky.rb
@@ -9,19 +9,19 @@ class Plucky::Query
   alias_method :remove_without_profiling, :remove
 
   def find_each(*args, &blk)
-    return profile_database_operation(__callee__, filtered_inspect(), *args, &blk)
+    profile_database_operation(__callee__, filtered_inspect(), *args, &blk)
   end
 
   def find_one(*args, &blk)
-    return profile_database_operation(__callee__, filtered_inspect(args[0]), *args, &blk)
+    profile_database_operation(__callee__, filtered_inspect(args[0]), *args, &blk)
   end
 
   def count(*args, &blk)
-    return profile_database_operation(__callee__, filtered_inspect(), *args, &blk)
+    profile_database_operation(__callee__, filtered_inspect(), *args, &blk)
   end
 
   def remove(*args, &blk)
-    return profile_database_operation(__callee__, filtered_inspect(), *args, &blk)
+    profile_database_operation(__callee__, filtered_inspect(), *args, &blk)
   end
 
   private

--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -11,7 +11,7 @@ class SqlPatches
     start  = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     result = yield
     record = ::Rack::MiniProfiler.record_sql(statement, elapsed_time(start), parameters)
-    return result, record
+    [result, record]
   end
 
   def self.should_measure?

--- a/spec/lib/profiler_spec.rb
+++ b/spec/lib/profiler_spec.rb
@@ -52,11 +52,11 @@ describe Rack::MiniProfiler do
   describe 'profile method' do
     class TestClass
       def foo(bar, baz)
-        return [bar, baz, yield]
+        [bar, baz, yield]
       end
 
       def self.bar(baz, boo)
-        return [baz, boo, yield]
+        [baz, boo, yield]
       end
     end
 


### PR DESCRIPTION
The rubocop.yml referres to the one of https://github.com/discourse/discourse (not sure why though). 

But with this commit: https://github.com/discourse/discourse/commit/eaf6096890120906b4f4e6282eb399afc5039559#diff-11a0d7906801d9dea0eccb85667ad811
the new dependency to `rubocop-discourse` was introduced with custom cops. 

This PR adds the new dependency and also fixes the "new" offenses of type `Style/RedundantReturn`