### PR TITLE
SECURITY: prevent XSS from malicious SQL query

### DIFF
--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -36,7 +36,7 @@ module Rack
           start_millis = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1000).to_i - page[:started]) - duration_ms
           super(
             execute_type: 3, # TODO
-            formatted_command_string: query,
+            formatted_command_string: ERB::Util.html_escape(query),
             stack_trace_snippet: stack_trace,
             start_milliseconds: start_millis,
             duration_milliseconds: duration_ms,

--- a/lib/mini_profiler/version.rb
+++ b/lib/mini_profiler/version.rb
@@ -2,6 +2,6 @@
 
 module Rack
   class MiniProfiler
-    VERSION = '1.1.3'
+    VERSION = '1.1.4'
   end
 end

--- a/spec/lib/timer_struct/sql_timer_struct_spec.rb
+++ b/spec/lib/timer_struct/sql_timer_struct_spec.rb
@@ -99,4 +99,17 @@ describe Rack::MiniProfiler::TimerStruct::Sql do
       Rack::MiniProfiler::TimerStruct::Sql.new("SELECT * FROM users", 200, @page, nil, params)
     end
   end
+
+  describe "#formatted_command_string" do
+    it "escapes malicious code" do
+      malicious_query = <<-SQL
+        UPDATE "table" SET "column" = '<iframe srcdoc="<script>alert(&#x22;hi&#x22;)</script>" />'
+      SQL
+      escaped_query = <<-SQL
+        UPDATE &quot;table&quot; SET &quot;column&quot; = &#39;&lt;iframe srcdoc=&quot;&lt;script&gt;alert(&amp;#x22;hi&amp;#x22;)&lt;/script&gt;&quot; /&gt;&#39;
+      SQL
+      sql = Rack::MiniProfiler::TimerStruct::Sql.new(malicious_query, 200, @page, nil, {})
+      expect(sql[:formatted_command_string]).to eq(escaped_query)
+    end
+  end
 end


### PR DESCRIPTION
The carefully prepared SQL query can be evaluated by javascript.

To prevent it, we need to escape HTML from the query.