### PR TITLE
Prepend Net::HTTP patch instead of class_eval and aliasing

### DIFF
--- a/lib/patches/net_patches.rb
+++ b/lib/patches/net_patches.rb
@@ -2,7 +2,7 @@
 
 if (defined?(Net) && defined?(Net::HTTP))
   module NetHTTPWithMiniProfiler
-    def request(request, body = nil, &block)
+    def request(request, *args, &block)
       Rack::MiniProfiler.step("Net::HTTP #{request.method} #{request.path}") do
         super
       end

--- a/lib/patches/net_patches.rb
+++ b/lib/patches/net_patches.rb
@@ -1,16 +1,13 @@
 # frozen_string_literal: true
 
 if (defined?(Net) && defined?(Net::HTTP))
-
-  Net::HTTP.class_eval do
-    def request_with_mini_profiler(*args, &block)
-      request = args[0]
+  module NetHTTPWithMiniProfiler
+    def request(request, body = nil, &block)
       Rack::MiniProfiler.step("Net::HTTP #{request.method} #{request.path}") do
-        request_without_mini_profiler(*args, &block)
+        super
       end
     end
-    alias request_without_mini_profiler request
-    alias request request_with_mini_profiler
   end
 
+  Net::HTTP.prepend(NetHTTPWithMiniProfiler)
 end


### PR DESCRIPTION
This patch fixes rack-mini-profiler working along with [http_logger](https://github.com/railsware/http_logger).

Both gems patch `Net::HTTP#request`, but `http_logger` does it using `prepend`, and `rack-mini-profiler` does old-school `class_eval`. 

Problem is that when both gems are on I get `stack overflow` errors, because calling `request_without_mini_profiler` caused calling `request_with_mini_profiler` and so forth.

I've changed `Net::HTTP` patch to use `prepend` as [http_logger does](https://github.com/railsware/http_logger/blob/master/lib/http_logger.rb#L204). It fixed the problem.

Prepend was added in ruby 2.0, and readme says that the gem supports 2.3+, so it's safe to use it.