### PR TITLE
gemspec: Point out homepage with HTTPS

### DIFF
--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.authors = ["Sam Saffron", "Robin Ward", "Aleks Totic"]
   s.description = "Profiling toolkit for Rack applications with Rails integration. Client Side profiling, DB profiling and Server profiling."
   s.email = "sam.saffron@gmail.com"
-  s.homepage = "http://miniprofiler.com"
+  s.homepage = "https://miniprofiler.com"
   s.license = "MIT"
   s.files = [
     'rack-mini-profiler.gemspec',


### PR DESCRIPTION
This PR uses `https:` for the homepage URI in the gemspec.