### PR TITLE
Fixing getResponseHeader for ancient ExtJS

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -818,7 +818,11 @@ var MiniProfiler = (function() {
           return;
         }
 
-        var stringIds = xhr.getResponseHeader("X-MiniProfiler-Ids");
+        if (typeof xhr.getResponseHeader === 'object') {
+          var stringIds = xhr.getResponseHeader["x-miniprofiler-ids"];
+        } else {
+          var stringIds = xhr.getResponseHeader("X-MiniProfiler-Ids");
+        }
 
         if (stringIds) {
           var ids = stringIds.split(",");


### PR DESCRIPTION
In old versions of ExtJS, `getResponseHeader` is an object and not a function. Adapting the code to support both.