### PR TITLE
DEV: Use ENV hash instead of constant to enable rails patches

### DIFF
--- a/lib/enable_rails_patches.rb
+++ b/lib/enable_rails_patches.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-ENV["MINI_PROFILER_ENABLE_RAILS_PATCHES"] = '1'
+module Rack
+  MINI_PROFILER_ENABLE_RAILS_PATCHES = true
+end

--- a/lib/enable_rails_patches.rb
+++ b/lib/enable_rails_patches.rb
@@ -1,7 +1,3 @@
 # frozen_string_literal: true
 
-module Rack
-  class MiniProfiler
-    ENABLE_RAILS_PATCHES = true
-  end
-end
+ENV["MINI_PROFILER_ENABLE_RAILS_PATCHES"] = '1'

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -8,7 +8,7 @@ module Rack
       attr_accessor :subscribe_sql_active_record
 
       def patch_rails?
-        ENV["MINI_PROFILER_ENABLE_RAILS_PATCHES"] == '1'
+        !!defined?(Rack::MINI_PROFILER_ENABLE_RAILS_PATCHES)
       end
 
       def generate_id

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -8,7 +8,7 @@ module Rack
       attr_accessor :subscribe_sql_active_record
 
       def patch_rails?
-        !!defined?(::Rack::MiniProfiler::ENABLE_RAILS_PATCHES)
+        ENV["MINI_PROFILER_ENABLE_RAILS_PATCHES"] == '1'
       end
 
       def generate_id


### PR DESCRIPTION
Version 2.0.0 ships with optional rails patches, and the way to turn the patches on is to have this in your Gemfile: `gem 'rack-mini-profiler', require: ['enable_rails_patches']`. The `enable_rails_patches.rb` file defines a constant under `Rack::MiniProfiler` which means the `Rack::MiniProfiler` class will always be defined, even though Mini Profiler is not fully loaded.

This means if you have code that checks `defined?(Rack::MiniProfiler)` before calling methods on `Rack::MiniProfiler` and Mini Profiler hasn't fully loaded yet, your code will 💥.

I don't see any downsides to using `ENV` instead of constant here, what do you think @SamSaffron? If this is problematic, we can still use a constant but it would need to be directly under `Rack` (or a global constant, but I don't think that's desirable) e.g. `Rack::MINI_PROFILER_ENABLE_RAILS_PATCHES`.