### PR TITLE
FIX: Fix client timings regression and bring back 'show trivial'

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -108,18 +108,8 @@ var MiniProfiler = (function() {
           // ie is buggy strip out functions
           var copy = {
             navigation: {},
-            timing: {}
+            timing: clientPerformance.timing.toJSON()
           };
-          var timing = extend({}, clientPerformance.timing);
-
-          for (p in timing) {
-            if (
-              timing.hasOwnProperty(p) &&
-              !(typeof timing[p] === "function")
-            ) {
-              copy.timing[p] = timing[p];
-            }
-          }
 
           if (clientPerformance.navigation) {
             copy.navigation.redirectCount =
@@ -147,10 +137,13 @@ var MiniProfiler = (function() {
         (function() {
           var request = new XMLHttpRequest();
           var url = options.path + "results";
-          var params = "id="
-            .concat(id, "&clientPerformance=")
-            .concat(clientPerformance, "&clientProbes=")
-            .concat(clientProbes, "&popup=1");
+          var params = {
+            id: id,
+            clientPerformance: clientPerformance,
+            clientProbes: clientProbes,
+            popup: 1
+          };
+          var queryParam = toQueryString(params);
           request.open("POST", url, true);
 
           request.onload = function() {
@@ -172,24 +165,45 @@ var MiniProfiler = (function() {
             "Content-Type",
             "application/x-www-form-urlencoded"
           );
-          request.send(params);
+          request.send(queryParam);
         })();
       }
     }
   };
 
-  var extend = function extend(out) {
-    out = out || {};
-
-    for (var i = 1; i < _arguments.length; i++) {
-      if (!_arguments[i]) continue;
-
-      for (var key in _arguments[i]) {
-        if (_arguments[i].hasOwnProperty(key)) out[key] = _arguments[i][key];
+  var toQueryString = function toQueryString(data, parentKey) {
+    var result = [];
+    for (var key in data) {
+      var val = data[key];
+      var newKey = !parentKey ? key : parentKey + "[" + key + "]";
+      if (
+        typeof val === "object" &&
+        !Array.isArray(val) &&
+        val !== null &&
+        val !== undefined
+      ) {
+        result[result.length] = toQueryString(val, newKey);
+      } else {
+        if (Array.isArray(val)) {
+          val.forEach(function(v) {
+            result[result.length] =
+              encodeURIComponent(newKey + "[]") + "=" + encodeURIComponent(v);
+          });
+        } else if (val === null || val === undefined) {
+          result[result.length] = encodeURIComponent(newKey) + "=";
+        } else {
+          result[result.length] =
+            encodeURIComponent(newKey) +
+            "=" +
+            encodeURIComponent(val.toString());
+        }
       }
     }
-
-    return out;
+    return result
+      .filter(function(element) {
+        return element && element.length > 0;
+      })
+      .join("&");
   };
 
   var renderTemplate = function renderTemplate(json) {

--- a/lib/html/includes.tmpl
+++ b/lib/html/includes.tmpl
@@ -128,8 +128,8 @@
   {{? it.custom_link}}
     <a href="{{= it.custom_link }}" class="profiler-custom-link" target="_blank">{{= it.custom_link_name }}</a>
   {{?}}
-  {{? it.has_trivial_timings}}
-    <a class="profiler-toggle-trivial" data-show-on-load="{{= it.has_all_trivial_timings }}" title="toggles any rows with &lt; {{= it.trivial_duration_threshold_milliseconds }} ms">
+  {{? it.page.has_trivial_timings}}
+    <a class="profiler-toggle-trivial" data-show-on-load="{{= it.page.has_all_trivial_timings }}" title="toggles any rows with &lt; {{= it.page.trivial_duration_threshold_milliseconds }} ms">
       show trivial
     </a>
   {{?}}

--- a/lib/html/vendor.js
+++ b/lib/html/vendor.js
@@ -11,7 +11,7 @@ var out=' <div class="profiler-result"> <div class="profiler-button ';if(it.has_
 }
 MiniProfiler.templates["linksTemplate"] = function anonymous(it
 ) {
-var out=' <a href="'+( MiniProfiler.shareUrl(it.page.id) )+'" class="profiler-share-profiler-results" target="_blank">share</a> <a href="'+( MiniProfiler.moreUrl(it.timing.name) )+'" class="profiler-more-actions">more</a> ';if(it.custom_link){out+=' <a href="'+( it.custom_link )+'" class="profiler-custom-link" target="_blank">'+( it.custom_link_name )+'</a> ';}out+=' ';if(it.has_trivial_timings){out+=' <a class="profiler-toggle-trivial" data-show-on-load="'+( it.has_all_trivial_timings )+'" title="toggles any rows with &lt; '+( it.trivial_duration_threshold_milliseconds )+' ms"> show trivial </a> ';}return out;
+var out=' <a href="'+( MiniProfiler.shareUrl(it.page.id) )+'" class="profiler-share-profiler-results" target="_blank">share</a> <a href="'+( MiniProfiler.moreUrl(it.timing.name) )+'" class="profiler-more-actions">more</a> ';if(it.custom_link){out+=' <a href="'+( it.custom_link )+'" class="profiler-custom-link" target="_blank">'+( it.custom_link_name )+'</a> ';}out+=' ';if(it.page.has_trivial_timings){out+=' <a class="profiler-toggle-trivial" data-show-on-load="'+( it.page.has_all_trivial_timings )+'" title="toggles any rows with &lt; '+( it.page.trivial_duration_threshold_milliseconds )+' ms"> show trivial </a> ';}return out;
 }
 MiniProfiler.templates["timingTemplate"] = function anonymous(it
 ) {

--- a/lib/mini_profiler/asset_version.rb
+++ b/lib/mini_profiler/asset_version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Rack
   class MiniProfiler
-    ASSET_VERSION = '67dd1c2571ced7fc74ae7f1813e47bdf'
+    ASSET_VERSION = '22e813e9a683ebee90a5afa948cffb0b'
   end
 end


### PR DESCRIPTION
Fix for https://github.com/MiniProfiler/rack-mini-profiler/issues/440

Client timings regressed when we removed jQuery a while ago; this PR fixes the regression. Tested on IE11 to ensure MP doesn't regress on IE11.

![image](https://user-images.githubusercontent.com/17474474/82532825-c5677b80-9b4a-11ea-9b1c-fe002f46473e.png)