### PR TITLE
DEV: Allow Net::HTTP#request patch to be applied with module prepend or method aliasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ If you don't want to manually require Mini Profiler:
 gem 'rack-mini-profiler', require: ['enable_rails_patches', 'rack-mini-profiler']
 ```
 
+#### `Net::HTTP` stack level too deep errors
+
+If you start seeing `SystemStackError: stack level too deep` errors from `Net::HTTP` after installing Mini Profiler, this means there is another patch for `Net::HTTP#request` that conflicts with Mini Profiler's patch in your application. To fix this, change `rack-mini-profiler` gem line in your `Gemfile` to the following:
+
+```ruby
+gem 'rack-mini-profiler', require: ['prepend_net_http_patch', 'rack-mini-profiler']
+```
+
+If you currently have `require: false`, remove the `'rack-mini-profiler'` string from the `require` array above so the gem line becomes like this:
+
+```ruby
+gem 'rack-mini-profiler', require: ['prepend_net_http_patch']
+```
+
+This conflict happens when a ruby method is patched twice, once using module prepend, and once using method aliasing. See this [ruby issue](https://bugs.ruby-lang.org/issues/11120) for details. The fix is to apply all patches the same way. Mini Profiler by default will apply its patch using method aliasing, but you can change that to module prepend by adding `require: ['prepend_net_http_patch']` to the gem line as shown above.
+
 #### Rails and manual initialization
 
 In case you need to make sure rack_mini_profiler is initialized after all other gems, or you want to execute some code before rack_mini_profiler required:

--- a/lib/patches/net_patches.rb
+++ b/lib/patches/net_patches.rb
@@ -2,15 +2,25 @@
 
 if (defined?(Net) && defined?(Net::HTTP))
 
-  Net::HTTP.class_eval do
-    def request_with_mini_profiler(*args, &block)
-      request = args[0]
-      Rack::MiniProfiler.step("Net::HTTP #{request.method} #{request.path}") do
-        request_without_mini_profiler(*args, &block)
+  if defined?(Rack::MINI_PROFILER_PREPEND_NET_HTTP_PATCH)
+    module NetHTTPWithMiniProfiler
+      def request(request, *args, &block)
+        Rack::MiniProfiler.step("Net::HTTP #{request.method} #{request.path}") do
+          super
+        end
       end
     end
-    alias request_without_mini_profiler request
-    alias request request_with_mini_profiler
+    Net::HTTP.prepend(NetHTTPWithMiniProfiler)
+  else
+    Net::HTTP.class_eval do
+      def request_with_mini_profiler(*args, &block)
+        request = args[0]
+        Rack::MiniProfiler.step("Net::HTTP #{request.method} #{request.path}") do
+          request_without_mini_profiler(*args, &block)
+        end
+      end
+      alias request_without_mini_profiler request
+      alias request request_with_mini_profiler
+    end
   end
-
 end

--- a/lib/prepend_net_http_patch.rb
+++ b/lib/prepend_net_http_patch.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Rack
+  MINI_PROFILER_PREPEND_NET_HTTP_PATCH = true
+end


### PR DESCRIPTION
@SamSaffron what do you think about this? This will allow people to choose how our Net::HTTP is applied like we allow our Rails patches to be optional. People who want our Net::HTTP patch to be applied using module prepend, they can do something like this in their Gemfile:

```ruby
gem 'rack-mini-profiler', require: ['prepend_net_http_patch']
```

Right now people who have other gems with patches that conflict with our patch are forced to either pin their Mini Profiler version and avoid updates, or remove one of the conflicting gems. I think it's nice if we can do something simple to avoid picking sides.