### PR TITLE
Remove Redis 4.2 warnings.

### DIFF
--- a/lib/mini_profiler/storage/redis_store.rb
+++ b/lib/mini_profiler/storage/redis_store.rb
@@ -33,7 +33,7 @@ module Rack
 
       def set_unviewed(user, id)
         key = user_key(user)
-        if redis.exists(prefixed_id(id))
+        if redis.call([:exists, prefixed_id(id)]) == 1
           expire_at = Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i + redis.ttl(prefixed_id(id))
           redis.zadd(key, expire_at, id)
         end
@@ -44,7 +44,7 @@ module Rack
         key = user_key(user)
         redis.del(key)
         ids.each do |id|
-          if redis.exists(prefixed_id(id))
+          if redis.call([:exists, prefixed_id(id)]) == 1
             expire_at = Process.clock_gettime(Process::CLOCK_MONOTONIC).to_i + redis.ttl(prefixed_id(id))
             redis.zadd(key, expire_at, id)
           end


### PR DESCRIPTION
Apps on Redis 4.2 and up will see a warning due to https://github.com/redis/redis-rb/commit/325752764995b02f17c3e5240ea489f641911d7d

