### PR TITLE
compatibility with peek-mysql2

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ gem 'rack-mini-profiler', require: ['prepend_net_http_patch']
 
 This conflict happens when a ruby method is patched twice, once using module prepend, and once using method aliasing. See this [ruby issue](https://bugs.ruby-lang.org/issues/11120) for details. The fix is to apply all patches the same way. Mini Profiler by default will apply its patch using method aliasing, but you can change that to module prepend by adding `require: ['prepend_net_http_patch']` to the gem line as shown above.
 
+#### `peek-mysql2` stack level too deep errors
+
+If you use peek-mysql2 with Rails >= 5, you'll need to use this gem spec in your Gemfile:
+
+```ruby
+gem 'rack-mini-profiler', require: ['prepend_mysql2_patch', 'rack-mini-profiler']
+```
+
+This should not be necessary with Rails < 5 because peek-mysql2 hooks into mysql2 gem in different ways depending on your Rails version.
+
 #### Rails and manual initialization
 
 In case you need to make sure rack_mini_profiler is initialized after all other gems, or you want to execute some code before rack_mini_profiler required:

--- a/lib/patches/db/mysql2.rb
+++ b/lib/patches/db/mysql2.rb
@@ -1,30 +1,34 @@
 # frozen_string_literal: true
 
-# The best kind of instrumentation is in the actual db provider, however we don't want to double instrument
-
 class Mysql2::Result
-  alias_method :each_without_profiling, :each
-  def each(*args, &blk)
-    return each_without_profiling(*args, &blk) unless defined?(@miniprofiler_sql_id)
+  module MiniProfiler
+    def each(*args, &blk)
+      return super unless defined?(@miniprofiler_sql_id)
 
-    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    result       = each_without_profiling(*args, &blk)
-    elapsed_time = SqlPatches.elapsed_time(start)
+      start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      result       = super
+      elapsed_time = SqlPatches.elapsed_time(start)
 
-    @miniprofiler_sql_id.report_reader_duration(elapsed_time)
-    result
+      @miniprofiler_sql_id.report_reader_duration(elapsed_time)
+      result
+    end
   end
+
+  prepend MiniProfiler
 end
 
 class Mysql2::Client
-  alias_method :query_without_profiling, :query
-  def query(*args, &blk)
-    return query_without_profiling(*args, &blk) unless SqlPatches.should_measure?
+  module MiniProfiler
+    def query(*args, &blk)
+      return super unless SqlPatches.should_measure?
 
-    result, record = SqlPatches.record_sql(args[0]) do
-      query_without_profiling(*args, &blk)
+      result, record = SqlPatches.record_sql(args[0]) do
+        super
+      end
+      result.instance_variable_set("@miniprofiler_sql_id", record) if result
+      result
     end
-    result.instance_variable_set("@miniprofiler_sql_id", record) if result
-    result
   end
+
+  prepend MiniProfiler
 end

--- a/lib/patches/db/mysql2.rb
+++ b/lib/patches/db/mysql2.rb
@@ -1,34 +1,7 @@
 # frozen_string_literal: true
 
-class Mysql2::Result
-  module MiniProfiler
-    def each(*args, &blk)
-      return super unless defined?(@miniprofiler_sql_id)
-
-      start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      result       = super
-      elapsed_time = SqlPatches.elapsed_time(start)
-
-      @miniprofiler_sql_id.report_reader_duration(elapsed_time)
-      result
-    end
-  end
-
-  prepend MiniProfiler
-end
-
-class Mysql2::Client
-  module MiniProfiler
-    def query(*args, &blk)
-      return super unless SqlPatches.should_measure?
-
-      result, record = SqlPatches.record_sql(args[0]) do
-        super
-      end
-      result.instance_variable_set("@miniprofiler_sql_id", record) if result
-      result
-    end
-  end
-
-  prepend MiniProfiler
+if defined?(Rack::MINI_PROFILER_PREPEND_MYSQL2_PATCH)
+  require "patches/db/mysql2/prepend"
+else
+  require "patches/db/mysql2/alias_method"
 end

--- a/lib/patches/db/mysql2/alias_method.rb
+++ b/lib/patches/db/mysql2/alias_method.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# The best kind of instrumentation is in the actual db provider, however we don't want to double instrument
+
+class Mysql2::Result
+  alias_method :each_without_profiling, :each
+  def each(*args, &blk)
+    return each_without_profiling(*args, &blk) unless defined?(@miniprofiler_sql_id)
+
+    start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result       = each_without_profiling(*args, &blk)
+    elapsed_time = SqlPatches.elapsed_time(start)
+
+    @miniprofiler_sql_id.report_reader_duration(elapsed_time)
+    result
+  end
+end
+
+class Mysql2::Client
+  alias_method :query_without_profiling, :query
+  def query(*args, &blk)
+    return query_without_profiling(*args, &blk) unless SqlPatches.should_measure?
+
+    result, record = SqlPatches.record_sql(args[0]) do
+      query_without_profiling(*args, &blk)
+    end
+    result.instance_variable_set("@miniprofiler_sql_id", record) if result
+    result
+  end
+end

--- a/lib/patches/db/mysql2/prepend.rb
+++ b/lib/patches/db/mysql2/prepend.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Mysql2::Result
+  module MiniProfiler
+    def each(*args, &blk)
+      return super unless defined?(@miniprofiler_sql_id)
+
+      start        = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      result       = super
+      elapsed_time = SqlPatches.elapsed_time(start)
+
+      @miniprofiler_sql_id.report_reader_duration(elapsed_time)
+      result
+    end
+  end
+
+  prepend MiniProfiler
+end
+
+class Mysql2::Client
+  module MiniProfiler
+    def query(*args, &blk)
+      return super unless SqlPatches.should_measure?
+
+      result, record = SqlPatches.record_sql(args[0]) do
+        super
+      end
+      result.instance_variable_set("@miniprofiler_sql_id", record) if result
+      result
+    end
+  end
+
+  prepend MiniProfiler
+end

--- a/lib/prepend_mysql2_patch.rb
+++ b/lib/prepend_mysql2_patch.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Rack
+  MINI_PROFILER_PREPEND_MYSQL2_PATCH = true
+end


### PR DESCRIPTION
don't use alias_method since [peek-mysql2](https://rubygems.org/gems/peek-mysql2) uses prepend on rails >= 5.
related to #437 and #444.

peek-mysql2 uses alias_method for rails < 5 though i opted not to distinguish as `prepend` was introduced with ruby 2.0 and this patch should work even if peek-mysql2 on rails 4 uses alias_method. but i might be wrong. let me know.

before this patch i've got this beautiful thing:

```
SystemStackError (stack level too deep):

peek-mysql2 (1.2.0) lib/peek-mysql2/timing.rb:8:in `ensure in query'
peek-mysql2 (1.2.0) lib/peek-mysql2/timing.rb:10:in `query'
rack-mini-profiler (2.0.0) lib/patches/db/mysql2.rb:25:in `block in query'
rack-mini-profiler (2.0.0) lib/patches/sql_patches.rb:12:in `record_sql'
rack-mini-profiler (2.0.0) lib/patches/db/mysql2.rb:24:in `query'

[...]

rack-mini-profiler (2.0.0) lib/patches/db/mysql2.rb:25:in `block in query'
rack-mini-profiler (2.0.0) lib/patches/sql_patches.rb:12:in `record_sql'
rack-mini-profiler (2.0.0) lib/patches/db/mysql2.rb:24:in `query'
peek-mysql2 (1.2.0) lib/peek-mysql2/timing.rb:6:in `query'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract_mysql_adapter.rb:201:in `block (2 levels) in execute'
activesupport (6.0.3.1) lib/active_support/dependencies/interlock.rb:48:in `block in permit_concurrent_loads'
activesupport (6.0.3.1) lib/active_support/concurrency/share_lock.rb:187:in `yield_shares'
activesupport (6.0.3.1) lib/active_support/dependencies/interlock.rb:47:in `permit_concurrent_loads'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract_mysql_adapter.rb:200:in `block in execute'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract_adapter.rb:722:in `block (2 levels) in log'
activesupport (6.0.3.1) lib/active_support/concurrency/load_interlock_aware_monitor.rb:26:in `block (2 levels) in synchronize'
activesupport (6.0.3.1) lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
activesupport (6.0.3.1) lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
activesupport (6.0.3.1) lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
activesupport (6.0.3.1) lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract_adapter.rb:721:in `block in log'
activesupport (6.0.3.1) lib/active_support/notifications/instrumenter.rb:24:in `instrument'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract_adapter.rb:712:in `log'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract_mysql_adapter.rb:199:in `execute'
activerecord (6.0.3.1) lib/active_record/connection_adapters/mysql/database_statements.rb:41:in `execute'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract_mysql_adapter.rb:742:in `configure_connection'
activerecord (6.0.3.1) lib/active_record/connection_adapters/mysql2_adapter.rb:133:in `configure_connection'
activerecord (6.0.3.1) lib/active_record/connection_adapters/mysql2_adapter.rb:44:in `initialize'
activerecord (6.0.3.1) lib/active_record/connection_adapters/mysql2_adapter.rb:25:in `new'
activerecord (6.0.3.1) lib/active_record/connection_adapters/mysql2_adapter.rb:25:in `mysql2_connection'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract/connection_pool.rb:887:in `new_connection'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract/connection_pool.rb:931:in `checkout_new_connection'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract/connection_pool.rb:910:in `try_to_checkout_new_connection'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract/connection_pool.rb:871:in `acquire_connection'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract/connection_pool.rb:593:in `checkout'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract/connection_pool.rb:437:in `connection'
activerecord (6.0.3.1) lib/active_record/connection_adapters/abstract/connection_pool.rb:1119:in `retrieve_connection'
activerecord (6.0.3.1) lib/active_record/connection_handling.rb:221:in `retrieve_connection'
activerecord (6.0.3.1) lib/active_record/connection_handling.rb:189:in `connection'
activerecord (6.0.3.1) lib/active_record/migration.rb:562:in `call'
actionpack (6.0.3.1) lib/action_dispatch/middleware/callbacks.rb:27:in `block in call'
activesupport (6.0.3.1) lib/active_support/callbacks.rb:101:in `run_callbacks'
actionpack (6.0.3.1) lib/action_dispatch/middleware/callbacks.rb:26:in `call'
actionpack (6.0.3.1) lib/action_dispatch/middleware/executor.rb:14:in `call'
actionpack (6.0.3.1) lib/action_dispatch/middleware/actionable_exceptions.rb:17:in `call'
actionpack (6.0.3.1) lib/action_dispatch/middleware/debug_exceptions.rb:32:in `call'
web-console (4.0.2) lib/web_console/middleware.rb:132:in `call_app'
web-console (4.0.2) lib/web_console/middleware.rb:28:in `block in call'
web-console (4.0.2) lib/web_console/middleware.rb:17:in `catch'
web-console (4.0.2) lib/web_console/middleware.rb:17:in `call'
actionpack (6.0.3.1) lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
railties (6.0.3.1) lib/rails/rack/logger.rb:37:in `call_app'
railties (6.0.3.1) lib/rails/rack/logger.rb:26:in `block in call'
activesupport (6.0.3.1) lib/active_support/tagged_logging.rb:80:in `block in tagged'
activesupport (6.0.3.1) lib/active_support/tagged_logging.rb:28:in `tagged'
activesupport (6.0.3.1) lib/active_support/tagged_logging.rb:80:in `tagged'
railties (6.0.3.1) lib/rails/rack/logger.rb:26:in `call'
sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:13:in `call'
actionpack (6.0.3.1) lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
actionpack (6.0.3.1) lib/action_dispatch/middleware/request_id.rb:27:in `call'
rack (2.2.2) lib/rack/method_override.rb:24:in `call'
rack (2.2.2) lib/rack/runtime.rb:22:in `call'
activesupport (6.0.3.1) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
actionpack (6.0.3.1) lib/action_dispatch/middleware/executor.rb:14:in `call'
actionpack (6.0.3.1) lib/action_dispatch/middleware/static.rb:126:in `call'
rack (2.2.2) lib/rack/sendfile.rb:110:in `call'
actionpack (6.0.3.1) lib/action_dispatch/middleware/host_authorization.rb:82:in `call'
rack-mini-profiler (2.0.0) lib/mini_profiler/profiler.rb:312:in `call'
webpacker (5.1.1) lib/webpacker/dev_server_proxy.rb:25:in `perform_request'
rack-proxy (0.6.5) lib/rack/proxy.rb:57:in `call'
railties (6.0.3.1) lib/rails/engine.rb:527:in `call'
puma (4.3.5) lib/puma/configuration.rb:228:in `call'
puma (4.3.5) lib/puma/server.rb:713:in `handle_request'
puma (4.3.5) lib/puma/server.rb:472:in `process_client'
puma (4.3.5) lib/puma/server.rb:328:in `block in run'
puma (4.3.5) lib/puma/thread_pool.rb:134:in `block in spawn_thread'
```