### PR TITLE
Fix false 404 in logs when visiting /rack-mini-profiler/requests

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -308,6 +308,15 @@ module Rack
               status, headers, body = @app.call(env)
             end
           end
+        elsif path == '/rack-mini-profiler/requests'
+          blank_page_html = <<~HTML
+            <html>
+              <head></head>
+              <body></body>
+            </html>
+          HTML
+
+          status, headers, body = [200, { 'Content-Type' => 'text/html' }, [blank_page_html.dup]]
         else
           status, headers, body = @app.call(env)
         end
@@ -364,16 +373,6 @@ module Rack
         return client_settings.handle_cookie(self.flamegraph(flamegraph))
       end
 
-      if path == '/rack-mini-profiler/requests'
-        blank_page_html = <<~HTML
-          <html>
-            <head></head>
-            <body></body>
-          </html>
-        HTML
-
-        status, headers, body = [200, { 'Content-Type' => 'text/html' }, [blank_page_html.dup]]
-      end
 
       begin
         @storage.save(page_struct)


### PR DESCRIPTION
Fix for https://github.com/MiniProfiler/rack-mini-profiler/issues/243#issuecomment-539843248.

I tested the `/rack-mini-profiler/requests` on a brand new Rails app and I noticed an `ActionController::RoutingError` error printed to the console, but the page actually worked as expected (I got MP badge speed). The backtrace of the error pointed to this line:

https://github.com/MiniProfiler/rack-mini-profiler/blob/029854f4c482cac97066ad78cf28eba9e52f007b/lib/mini_profiler/profiler.rb#L312

What is happening here is we are calling the next middlewares in the stack before we check for `path == '/rack-mini-profiler/requests'` which causes Rails to print that error because it doesn't recognize our route (rightfully so). The fix is to simply do our check before we call the next middleware in the chain.