### PR TITLE
FEATURE: Allow skip_paths config to contain regular expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Option|Default|Description
 -------|---|--------
 pre_authorize_cb|Rails: dev only<br>Rack: always on|A lambda callback that returns true to make mini_profiler visible on a given request.
 position|`'top-left'`|Display mini_profiler on `'top-right'`, `'top-left'`, `'bottom-right'` or `'bottom-left'`.
-skip_paths|`[]`|Paths that skip profiling.
+skip_paths|`[]`|An array of paths that skip profiling. Both `String` and `Regexp` are acceptable in the array.
 skip_schema_queries|Rails dev: `true`<br>Othwerwise: `false`|`true` to skip schema queries.
 auto_inject|`true`|`true` to inject the miniprofiler script in the page.
 backtrace_ignores|`[]`|Regexes of lines to be removed from backtraces.

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -257,6 +257,14 @@ describe Rack::MiniProfiler do
       expect(last_response.headers.has_key?('X-MiniProfiler-Ids')).to be(true)
     end
 
+    it "skip_paths can contain regular expressions" do
+      Rack::MiniProfiler.config.skip_paths = [/path[^1]/]
+      get '/path2/a'
+      expect(last_response.headers.has_key?('X-MiniProfiler-Ids')).to be(false)
+      get '/path1/a'
+      expect(last_response.headers.has_key?('X-MiniProfiler-Ids')).to be(true)
+    end
+
     it 'disables default functionality' do
       Rack::MiniProfiler.config.enabled = false
       get '/html'

--- a/spec/support/common_store_spec.rb
+++ b/spec/support/common_store_spec.rb
@@ -119,7 +119,7 @@ RSpec.shared_examples "snapshots storage" do |store|
       page = Rack::MiniProfiler::TimerStruct::Page.new({})
       page[:root].record_time(400)
       store.push_snapshot(page, Rack::MiniProfiler::Config.default)
-      
+
       loaded = store.load_snapshot(page[:id])
       expect(loaded).to be_instance_of(Rack::MiniProfiler::TimerStruct::Page)
       expect(loaded[:id]).to eq(page[:id])

--- a/website/sample.rb
+++ b/website/sample.rb
@@ -19,7 +19,7 @@ class SampleStorage < Rack::MiniProfiler::AbstractStore
     @page_struct
   end
   alias_method :load_snapshot, :load
-  
+
   def save(*args)
   end
 
@@ -49,7 +49,7 @@ class SampleStorage < Rack::MiniProfiler::AbstractStore
         methods.sample,
         paths.sample,
         SecureRandom.rand * @multipliers.sample,
-        ((Time.new.to_f - @time_units.sample * @time_multipliers.sample) * 1000).round
+        ((Time.now.to_f - @time_units.sample * @time_multipliers.sample) * 1000).round
       )
     end
     @snapshots.each_slice(batch_size) { |batch| blk.call(batch) }


### PR DESCRIPTION
@SamSaffron when I was trying to enable snapshots on Discourse, I noticed we don't use Mini Profiler's `skip_paths`
 config but instead use `pre_authorize_cb` to skip paths:

https://github.com/discourse/discourse/blob/90eeb8f7d95bf8e06adb34acbbb65e2c743e551f/config/initializers/006-mini_profiler.rb#L53-L58

We also use `pre_authorize_cb` to disable profiling on phones/tablets.

Skipping paths in `pre_authorize_cb` is problematic for snapshotting because requests that fail the `pre_authorize_cb` check are eligible for snapshotting, and we do want requests from phones/tablets to be eligible for snapshotting, but we never want (I think) requests to skipped paths to be eligible for snapshotting (e.g. I don't think we want snapshots for assets requests).

The only thing stopping us from using `skip_paths` is that we want regular expressions but `skip_paths` currently accepts strings only. This PR allows both strings and regular expressions in `skip_paths`.