### PR TITLE
Make MiniProfiler.profile_method compatible with Ruby 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
         options: --health-cmd "timeout 5 bash -c 'cat < /dev/null > /dev/udp/127.0.0.1/11211'" --health-interval 10s --health-timeout 5s --health-retries 5
     strategy:
       matrix:
-        ruby: ["2.7", "2.6", "2.5"]
+        ruby: ["3.0", "2.7", "2.6", "2.5"]
         redis: ["5.x"]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Setup redis

--- a/lib/mini_profiler/profiling_methods.rb
+++ b/lib/mini_profiler/profiling_methods.rb
@@ -81,37 +81,75 @@ module Rack
         end
 
         klass.send :alias_method, without_profiling, method
-        klass.send :define_method, with_profiling do |*args, &orig|
-          return self.send without_profiling, *args, &orig unless Rack::MiniProfiler.current
+        # TODO: Remove when rubies < 2.7 are no longer supported
+        if ruby_2_7_or_higher?
+          klass.send :define_method, with_profiling do |*args, **kwargs, &orig|
+            return self.send without_profiling, *args, **kwargs, &orig unless Rack::MiniProfiler.current
 
-          name = default_name
-          if blk
-            name =
-              if respond_to?(:instance_exec)
-                instance_exec(*args, &blk)
-              else
-                # deprecated in Rails 4.x
-                blk.bind(self).call(*args)
-              end
-          end
-
-          parent_timer = Rack::MiniProfiler.current.current_timer
-
-          if type == :counter
-            start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-            begin
-              self.send without_profiling, *args, &orig
-            ensure
-              duration_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start).to_f * 1000
-              parent_timer.add_custom(name, duration_ms, Rack::MiniProfiler.current.page_struct)
+            name = default_name
+            if blk
+              name =
+                if respond_to?(:instance_exec)
+                  instance_exec(*args, **kwargs, &blk)
+                else
+                  # deprecated in Rails 4.x
+                  blk.bind(self).call(*args, **kwargs)
+                end
             end
-          else
-            Rack::MiniProfiler.current.current_timer = current_timer = parent_timer.add_child(name)
-            begin
-              self.send without_profiling, *args, &orig
-            ensure
-              current_timer.record_time
-              Rack::MiniProfiler.current.current_timer = parent_timer
+
+            parent_timer = Rack::MiniProfiler.current.current_timer
+
+            if type == :counter
+              start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              begin
+                self.send without_profiling, *args, **kwargs, &orig
+              ensure
+                duration_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start).to_f * 1000
+                parent_timer.add_custom(name, duration_ms, Rack::MiniProfiler.current.page_struct)
+              end
+            else
+              Rack::MiniProfiler.current.current_timer = current_timer = parent_timer.add_child(name)
+              begin
+                self.send without_profiling, *args, **kwargs, &orig
+              ensure
+                current_timer.record_time
+                Rack::MiniProfiler.current.current_timer = parent_timer
+              end
+            end
+          end
+        else
+          klass.send :define_method, with_profiling do |*args, &orig|
+            return self.send without_profiling, *args, &orig unless Rack::MiniProfiler.current
+
+            name = default_name
+            if blk
+              name =
+                if respond_to?(:instance_exec)
+                  instance_exec(*args, &blk)
+                else
+                  # deprecated in Rails 4.x
+                  blk.bind(self).call(*args)
+                end
+            end
+
+            parent_timer = Rack::MiniProfiler.current.current_timer
+
+            if type == :counter
+              start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+              begin
+                self.send without_profiling, *args, &orig
+              ensure
+                duration_ms = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start).to_f * 1000
+                parent_timer.add_custom(name, duration_ms, Rack::MiniProfiler.current.page_struct)
+              end
+            else
+              Rack::MiniProfiler.current.current_timer = current_timer = parent_timer.add_child(name)
+              begin
+                self.send without_profiling, *args, &orig
+              ensure
+                current_timer.record_time
+                Rack::MiniProfiler.current.current_timer = parent_timer
+              end
             end
           end
         end
@@ -155,6 +193,9 @@ module Rack
         method.to_s.gsub(/[\?\!]/, "")
       end
 
+      def ruby_2_7_or_higher?
+        @ruby_2_7_or_higher ||= Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.7.0')
+      end
     end
   end
 end

--- a/spec/lib/profiler_spec.rb
+++ b/spec/lib/profiler_spec.rb
@@ -81,8 +81,12 @@ describe Rack::MiniProfiler do
     end
 
     it 'optional positional args and keyword args should not conflict' do
-      Rack::MiniProfiler.profile_method(TestClass, :kwargs_test)
+      block_args = nil
+      Rack::MiniProfiler.profile_method(TestClass, :kwargs_test) do |a, b, c = 1, d: 4|
+        block_args = { a: a, b: b, c: c, d: d }
+      end
       expect(TestClass.new.kwargs_test(10, 20, d: 90)).to eq({ a: 10, b: 20, c: 1, d: 90 })
+      expect(block_args).to eq({ a: 10, b: 20, c: 1, d: 90 })
     end
   end
 

--- a/spec/lib/profiler_spec.rb
+++ b/spec/lib/profiler_spec.rb
@@ -55,6 +55,10 @@ describe Rack::MiniProfiler do
         [bar, baz, yield]
       end
 
+      def kwargs_test(a, b, c = 1, d: 4)
+        { a: a, b: b, c: c, d: d }
+      end
+
       def self.bar(baz, boo)
         [baz, boo, yield]
       end
@@ -76,6 +80,10 @@ describe Rack::MiniProfiler do
       Rack::MiniProfiler.unprofile_singleton_method TestClass, :bar
     end
 
+    it 'optional positional args and keyword args should not conflict' do
+      Rack::MiniProfiler.profile_method(TestClass, :kwargs_test)
+      expect(TestClass.new.kwargs_test(10, 20, d: 90)).to eq({ a: 10, b: 20, c: 1, d: 90 })
+    end
   end
 
   describe 'step' do


### PR DESCRIPTION
Fix for https://github.com/MiniProfiler/rack-mini-profiler/issues/480.

We can't pass `**kwargs` unconditionally because it would break backward compatibility with ruby < 2.7:

```
~ » cat ~/test.rb
class A
  def t(a, b = 2)
    { a: a, b: b }
  end
end

A.send :alias_method, 'old_t', 't'
A.send :define_method, 't' do |*args, **kwargs, &blk|
  self.send 'old_t', *args, **kwargs, &blk
end

puts RUBY_VERSION
puts A.new.t(10)

~ » RBENV_VERSION=2.7.0 rbenv exec ruby ~/test.rb
2.7.0
{:a=>10, :b=>2}  # <=== 👍 

~ » rbenv exec ruby ~/test.rb
2.6.6
{:a=>10, :b=>{}} # <=== 👎 
```