### PR TITLE
Add memory_profiler error when not installed

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -281,6 +281,15 @@ module Rack
       # profile memory
       if query_string =~ /pp=profile-memory/
         return tool_disabled_message(client_settings) if !advanced_debugging_enabled?
+
+        unless defined?(MemoryProfiler) && MemoryProfiler.respond_to?(:report)
+          message = "Please install the memory_profiler gem and require it: add gem 'memory_profiler' to your Gemfile"
+          _, _, body = @app.call(env)
+          body.close if body.respond_to? :close
+
+          return client_settings.handle_cookie(text_result(message))
+        end
+
         query_params = Rack::Utils.parse_nested_query(query_string)
         options = {
           ignore_files: query_params['memory_profiler_ignore_files'],

--- a/spec/integration/middleware_spec.rb
+++ b/spec/integration/middleware_spec.rb
@@ -39,7 +39,7 @@ describe Rack::MiniProfiler do
     end
   end
 
-  describe 'with analyze-memory query' do
+  describe 'when enable_advanced_debugging_tools is true' do
     def app
       Rack::Builder.new do
         use Rack::MiniProfiler
@@ -47,10 +47,32 @@ describe Rack::MiniProfiler do
       end
     end
 
-    it 'should return ObjectSpace statistics if advanced tools are enabled' do
-      Rack::MiniProfiler.config.enable_advanced_debugging_tools = true
-      do_get(pp: 'analyze-memory')
-      expect(last_response.body).to include('Largest strings:')
+    before(:each) { Rack::MiniProfiler.config.enable_advanced_debugging_tools = true }
+
+    describe 'with analyze-memory query' do
+      it 'should return ObjectSpace statistics' do
+        do_get(pp: 'analyze-memory')
+        expect(last_response.body).to include('Largest strings:')
+      end
+    end
+
+    describe 'with profile-memory query' do
+      it 'should return memory_profiler error message' do
+        do_get(pp: 'profile-memory')
+        expect(last_response.body).to eq(
+          'Please install the memory_profiler gem and require it: add gem \'memory_profiler\' to your Gemfile'
+        )
+      end
+    end
+
+    describe 'with flamegraph query' do
+      it 'should return stackprof error message' do
+        Rack::MiniProfiler.config.enable_advanced_debugging_tools = true
+        do_get(pp: 'flamegraph')
+        expect(last_response.body).to eq(
+          'Please install the stackprof gem and require it: add gem \'stackprof\' to your Gemfile'
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Adds error message when `memory_profiler` isn't installed. The wording and logic is borrowed from the error you get from `pp=flamegraph` when `stackprof` isn't installed. I also added some integration tests for each feature.