### PR TITLE
Handle AbortError if fetch is cancelled in-flight

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -983,7 +983,12 @@ var _MiniProfiler = (function() {
             } catch (e) {
               console.error(e);
             }
+          }).catch(function(e){
+            if (e.name !== 'AbortError') {
+              console.error(event);
+            }
           });
+
           return originalFetchRun;
         };
       }


### PR DESCRIPTION
Resolves #489 

Per guidance here: https://developers.google.com/web/updates/2017/09/abortable-fetch#reacting_to_an_aborted_fetch 

> When you abort an async operation, the promise rejects with a DOMException named AbortError
> You don't often want to show an error message if the user aborted the operation, as it isn't an "error" if you successfully do what the user asked. To avoid this, use an if-statement such as the one above to handle abort errors specifically.

Users may choose how to handle the rejected promise in their own code, but the profiler will not raise an uncaught exception.