### PR TITLE
Offer "allow_authorized" as an alternative to "whitelist"

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,21 +235,21 @@ rack-mini-profiler is designed with production profiling in mind. To enable that
 
 Note:
 
-Out-of-the-box we will initialize the `authorization_mode` to `:whitelist` in production. However, in some cases we may not be able to do it:
+Out-of-the-box we will initialize the `authorization_mode` to `:allow_authorized` in production. However, in some cases we may not be able to do it:
 
-- If you are running in development or test we will not enable whitelist mode
+- If you are running in development or test we will not enable the explicit authorization mode
 - If you use `require: false` on rack_mini_profiler we are unlikely to be able to run the railtie
 - If you are running outside of rails we will not run the railtie
 
 In those cases use:
 
 ```ruby
-Rack::MiniProfiler.config.authorization_mode = :whitelist
+Rack::MiniProfiler.config.authorization_mode = :allow_authorized
 ```
 
 When deciding to fully profile a page mini profiler consults with the `authorization_mode`
 
-By default in production we attempt to set the authorization mode to `:whitelist` meaning that end user will only be able to see requests where somewhere `Rack::MiniProfiler.authorize_request` is invoked.
+By default in production we attempt to set the authorization mode to `:allow_authorized` meaning that end user will only be able to see requests where somewhere `Rack::MiniProfiler.authorize_request` is invoked.
 
 In development we run in the `:allow_all` authorization mode meaning every request is profiled and displayed to the end user.
 

--- a/lib/mini_profiler/client_settings.rb
+++ b/lib/mini_profiler/client_settings.rb
@@ -42,7 +42,7 @@ module Rack
       def handle_cookie(result)
         status, headers, _body = result
 
-        if (MiniProfiler.config.authorization_mode == :whitelist && !MiniProfiler.request_authorized?)
+        if (MiniProfiler.config.authorization_mode == :allow_authorized && !MiniProfiler.request_authorized?)
           # this is non-obvious, don't kill the profiling cookie on errors or short requests
           # this ensures that stuff that never reaches the rails stack does not kill profiling
           if status.to_i >= 200 && status.to_i < 300 && ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - @start) > 0.1)
@@ -59,7 +59,7 @@ module Rack
 
         tokens_changed = false
 
-        if MiniProfiler.request_authorized? && MiniProfiler.config.authorization_mode == :whitelist
+        if MiniProfiler.request_authorized? && MiniProfiler.config.authorization_mode == :allow_authorized
           @allowed_tokens ||= @store.allowed_tokens
           tokens_changed = !@orig_auth_tokens || ((@allowed_tokens - @orig_auth_tokens).length > 0)
         end
@@ -90,7 +90,7 @@ module Rack
       def has_valid_cookie?
         valid_cookie = !@cookie.nil?
 
-        if (MiniProfiler.config.authorization_mode == :whitelist) && valid_cookie
+        if (MiniProfiler.config.authorization_mode == :allow_authorized) && valid_cookie
           begin
             @allowed_tokens ||= @store.allowed_tokens
           rescue => e

--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -86,6 +86,20 @@ module Rack
 
       attr_reader :assets_url
 
+      def authorization_mode=(mode)
+        if mode == :whitelist
+          warn "[DEPRECATION] `:whitelist` authorization mode is deprecated. Please use `:allow_authorized` instead."
+
+          mode = :allow_authorized
+        end
+
+        warn <<~DEP unless mode == :allow_authorized || mode == :allow_all
+          [DEPRECATION] unknown authorization mode #{mode}. Expected `:allow_all` or `:allow_authorized`.
+        DEP
+
+        @authorization_mode = mode
+      end
+
       def assets_url=(lmbda)
         if defined?(Rack::MiniProfilerRails)
           Rack::MiniProfilerRails.create_engine

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -213,7 +213,7 @@ module Rack
     def call(env)
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       client_settings = ClientSettings.new(env, @storage, start)
-      MiniProfiler.deauthorize_request if @config.authorization_mode == :whitelist
+      MiniProfiler.deauthorize_request if @config.authorization_mode == :allow_authorized
 
       status = headers = body = nil
       query_string = env['QUERY_STRING']
@@ -239,7 +239,7 @@ module Rack
       skip_it = (@config.pre_authorize_cb && !@config.pre_authorize_cb.call(env))
 
       if skip_it || (
-        @config.authorization_mode == :whitelist &&
+        @config.authorization_mode == :allow_authorized &&
         !client_settings.has_valid_cookie?
       )
         if take_snapshot?(path)
@@ -388,7 +388,7 @@ module Rack
 
       skip_it = current.discard
 
-      if (config.authorization_mode == :whitelist && !MiniProfiler.request_authorized?)
+      if (config.authorization_mode == :allow_authorized && !MiniProfiler.request_authorized?)
         skip_it = true
       end
 

--- a/lib/mini_profiler/storage/abstract_store.rb
+++ b/lib/mini_profiler/storage/abstract_store.rb
@@ -36,7 +36,7 @@ module Rack
         ""
       end
 
-      # a list of tokens that are permitted to access profiler in whitelist mode
+      # a list of tokens that are permitted to access profiler in explicit mode
       def allowed_tokens
         raise NotImplementedError.new("allowed_tokens is not implemented")
       end

--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -35,7 +35,7 @@ module Rack::MiniProfilerRails
     end
 
     unless Rails.env.development? || Rails.env.test?
-      c.authorization_mode = :whitelist
+      c.authorization_mode = :allow_authorized
     end
 
     if Rails.logger

--- a/spec/lib/client_settings_spec.rb
+++ b/spec/lib/client_settings_spec.rb
@@ -41,7 +41,7 @@ describe Rack::MiniProfiler::ClientSettings do
     end
 
     it 'writes auth token for authorized reqs' do
-      Rack::MiniProfiler.config.authorization_mode = :whitelist
+      Rack::MiniProfiler.config.authorization_mode = :allow_authorized
       Rack::MiniProfiler.authorize_request
       hash = {}
       @settings.write!(hash)
@@ -49,7 +49,7 @@ describe Rack::MiniProfiler::ClientSettings do
     end
 
     it 'does nothing on short unauthed requests' do
-      Rack::MiniProfiler.config.authorization_mode = :whitelist
+      Rack::MiniProfiler.config.authorization_mode = :allow_authorized
       Rack::MiniProfiler.deauthorize_request
       hash = {}
       @settings.handle_cookie([200, hash, []])
@@ -58,7 +58,7 @@ describe Rack::MiniProfiler::ClientSettings do
     end
 
     it 'discards on long unauthed requests' do
-      Rack::MiniProfiler.config.authorization_mode = :whitelist
+      Rack::MiniProfiler.config.authorization_mode = :allow_authorized
       Rack::MiniProfiler.deauthorize_request
       hash = {}
       clock_travel(Process.clock_gettime(Process::CLOCK_MONOTONIC) + 1) do

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -9,5 +9,28 @@ module Rack
       end
     end
 
+    describe 'authorization_mode' do
+      before do
+        @config = MiniProfiler::Config.default
+      end
+
+      it 'is false by default' do
+        expect(@config.authorization_mode).to be(:allow_all)
+      end
+
+      it 'is set to :allow_authorized when given :whitelist' do
+        expect { @config.authorization_mode = :whitelist }.to output(<<~DEP).to_stderr
+          [DEPRECATION] `:whitelist` authorization mode is deprecated. Please use `:allow_authorized` instead.
+        DEP
+
+        expect(@config.authorization_mode).to eq :allow_authorized
+      end
+
+      it 'emits deprecation warning if set to an unrecognized mode' do
+        expect { @config.authorization_mode = :unknown_mode }.to output(<<~DEP).to_stderr
+          [DEPRECATION] unknown authorization mode unknown_mode. Expected `:allow_all` or `:allow_authorized`.
+        DEP
+      end
+    end
   end
 end


### PR DESCRIPTION
  - Some teams and projects will wish to use rack-mini-profiler without
  needing to use terminology they feel is exclusive/biased/harmful
  - This change adds support for 'allow_authorized' as a suitable alternative
  for replacing 'whitelist'
  - In truth, the concept of 'explicit authorization' is more true to how this
  library works: there is no list of allowed endpoints, but rather some
  endpoints are explicitly allowed and others are not.
  - No immediate change required for clients -- they can continue to specify whatever
  authorization mode they used before this change. Using the old authorization mode identifier will emit a deprecation warning and set the authorization mode to ":allow_authorized" instead.
  - Include tests showing backward compatibility and support for the new
  authorization mode identifier.
  - Update integration spec to: utilize :allow_authorized authorization mode; bring ancillary language into alignment