### PR TITLE
Fix profiler pop-up extending beyond the window, impossible to scroll

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -401,7 +401,7 @@ var _MiniProfiler = (function() {
     var px = button.offsetTop - 1,
       // position next to the button we clicked
       windowHeight = window.innerHeight,
-      maxHeight = windowHeight - 40; // make sure the popup doesn't extend below the fold
+      maxHeight = windowHeight - px - 40; // make sure the popup doesn't extend below the fold
 
     popup.style[options.renderVerticalPosition] = "".concat(px, "px");
     popup.style.maxHeight = "".concat(maxHeight, "px");


### PR DESCRIPTION
When viewing a request that is not the first, the bottom of the pop-up comes outside of the window. Even scrolling all the way doesn't let you see the bottom of it.

Before/After (blocked out unnecessary info)
<img width="840" alt="Screenshot 2021-04-14 at 00 57 07" src="https://user-images.githubusercontent.com/347921/114627199-8c357e00-9cbd-11eb-88e6-9421d7adb4a4.png">
<img width="840" alt="Screenshot 2021-04-14 at 00 58 04" src="https://user-images.githubusercontent.com/347921/114627217-90fa3200-9cbd-11eb-97f6-68ecfd43c1ce.png">
