### PR TITLE
Add charset=utf-8 to content-type text/plain

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -630,7 +630,7 @@ module Rack
     end
 
     def text_result(body)
-      headers = { 'Content-Type' => 'text/plain' }
+      headers = { 'Content-Type' => 'text/plain; charset=utf-8' }
       [200, headers, [body]]
     end
 


### PR DESCRIPTION
`memory_profiler` reports may contain non-ASCII characters (e.g. Allocated String Report section), so if charset is not specified, the results in `?pp=profile-memory` may be garbled.

Fixed this problem by specifying charset for `Content-Type` of `text_result`.