### PR TITLE
Allow content-type header with charset on test.

### DIFF
--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -393,7 +393,7 @@ describe Rack::MiniProfiler do
   describe 'gc profiler' do
     it "should return a report" do
       get '/html?pp=profile-gc'
-      expect(last_response.header['Content-Type']).to eq('text/plain')
+      expect(last_response.header['Content-Type']).to include('text/plain')
     end
   end
 


### PR DESCRIPTION
Specs fails when the Content-Type is "text/plain; charset=utf-8"