### PR TITLE
Improve development section from Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,19 +463,20 @@ end
 If you want to contribute to this project, that's great, thank you! You can run the following rake task:
 
 ```
+$ BUNDLE_GEMFILE=website/Gemfile bundle install
 $ bundle exec rake client_dev
 ```
 
-which will start a local Sinatra server at `http://localhost:9292` where you'll be able to preview your changes. Refreshing the page should be enough to see any changes you make to files in the `lib/html` directory.
+This will start a local Sinatra server at `http://localhost:9292` where you'll be able to preview your changes. Refreshing the page should be enough to see any changes you make to files in the `lib/html` directory.
 
 ## Running the Specs
+
+You need Memcached and Redis services running for the specs.
 
 ```
 $ rake build
 $ rake spec
 ```
-
-Additionally you can also run `autotest` if you like.
 
 ## Licence
 


### PR DESCRIPTION
- Add note about bundle install on `website/`
- Add note about required services for specs
- Remove autotest note. It was removed on https://github.com/MiniProfiler/rack-mini-profiler/pull/21