### PR TITLE
Remove old css

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ $ bundle exec rake client_dev
 
 This will start a local Sinatra server at `http://localhost:9292` where you'll be able to preview your changes. Refreshing the page should be enough to see any changes you make to files in the `lib/html` directory.
 
+Make sure to prepend `bundle exec` before any Rake tasks you run.
+
 ## Running the Specs
 
 You need Memcached and Redis services running for the specs.

--- a/lib/html/includes.css
+++ b/lib/html/includes.css
@@ -241,8 +241,6 @@
       left: 0px; }
       .profiler-results.profiler-top.profiler-left.profiler-no-controls .profiler-totals, .profiler-results.profiler-top.profiler-left.profiler-no-controls .profiler-result:last-child .profiler-button,
       .profiler-results.profiler-top.profiler-left .profiler-controls {
-        -webkit-border-bottom-right-radius: 10px;
-        -moz-border-radius-bottomright: 10px;
         border-bottom-right-radius: 10px; }
       .profiler-results.profiler-top.profiler-left .profiler-button,
       .profiler-results.profiler-top.profiler-left .profiler-controls {
@@ -251,8 +249,6 @@
       right: 0px; }
       .profiler-results.profiler-top.profiler-right.profiler-no-controls .profiler-totals, .profiler-results.profiler-top.profiler-right.profiler-no-controls .profiler-result:last-child .profiler-button,
       .profiler-results.profiler-top.profiler-right .profiler-controls {
-        -webkit-border-bottom-left-radius: 10px;
-        -moz-border-radius-bottomleft: 10px;
         border-bottom-left-radius: 10px; }
       .profiler-results.profiler-top.profiler-right .profiler-button,
       .profiler-results.profiler-top.profiler-right .profiler-controls {
@@ -263,8 +259,6 @@
       left: 0px; }
       .profiler-results.profiler-bottom.profiler-left.profiler-no-controls .profiler-totals, .profiler-results.profiler-bottom.profiler-left.profiler-no-controls .profiler-result:first-child .profiler-button,
       .profiler-results.profiler-bottom.profiler-left .profiler-controls {
-        -webkit-border-top-right-radius: 10px;
-        -moz-border-radius-topright: 10px;
         border-top-right-radius: 10px; }
       .profiler-results.profiler-bottom.profiler-left .profiler-button,
       .profiler-results.profiler-bottom.profiler-left .profiler-controls {
@@ -273,8 +267,6 @@
       right: 0px; }
       .profiler-results.profiler-bottom.profiler-right.profiler-no-controls .profiler-totals, .profiler-results.profiler-bottom.profiler-right.profiler-no-controls .profiler-result:first-child .profiler-button,
       .profiler-results.profiler-bottom.profiler-right .profiler-controls {
-        -webkit-border-bottom-top-radius: 10px;
-        -moz-border-radius-topleft: 10px;
         border-top-left-radius: 10px; }
       .profiler-results.profiler-bottom.profiler-right .profiler-button,
       .profiler-results.profiler-bottom.profiler-right .profiler-controls {
@@ -332,8 +324,6 @@
     text-align: left;
     line-height: 18px;
     overflow: auto;
-    -moz-box-shadow: 0px 1px 15px #555;
-    -webkit-box-shadow: 0px 1px 15px #555;
     box-shadow: 0px 1px 15px #555; }
     .profiler-results .profiler-popup .profiler-info {
       margin-bottom: 3px;

--- a/lib/html/includes.css
+++ b/lib/html/includes.css
@@ -69,7 +69,7 @@
   .profiler-result .custom-fields-title,
   .profiler-queries .custom-fields-title {
     color: #555;
-    font: Helvetica, Arial, sans-serif;
+    font-family: Helvetica, Arial, sans-serif;
     font-size: 14px; }
   .mp-snapshots .ta-left,
   .profiler-result .ta-left,

--- a/lib/html/includes.scss
+++ b/lib/html/includes.scss
@@ -1,6 +1,4 @@
 @mixin box-shadow($dx, $dy, $radius, $color) {
-  -moz-box-shadow: $dx $dy $radius $color;
-  -webkit-box-shadow: $dx $dy $radius $color;
   box-shadow: $dx $dy $radius $color;
 }
 
@@ -328,8 +326,6 @@ $zindex: 2147483640; // near 32bit max 2147483647
       &.profiler-no-controls .profiler-totals,
       &.profiler-no-controls .profiler-result:last-child .profiler-button,
       .profiler-controls {
-        -webkit-border-bottom-right-radius: $radius;
-        -moz-border-radius-bottomright: $radius;
         border-bottom-right-radius: $radius;
       }
 
@@ -345,8 +341,6 @@ $zindex: 2147483640; // near 32bit max 2147483647
       &.profiler-no-controls .profiler-totals,
       &.profiler-no-controls .profiler-result:last-child .profiler-button,
       .profiler-controls {
-        -webkit-border-bottom-left-radius: $radius;
-        -moz-border-radius-bottomleft: $radius;
         border-bottom-left-radius: $radius;
       }
 
@@ -366,8 +360,6 @@ $zindex: 2147483640; // near 32bit max 2147483647
       &.profiler-no-controls .profiler-totals,
       &.profiler-no-controls .profiler-result:first-child .profiler-button,
       .profiler-controls {
-        -webkit-border-top-right-radius: $radius;
-        -moz-border-radius-topright: $radius;
         border-top-right-radius: $radius;
       }
 
@@ -383,8 +375,6 @@ $zindex: 2147483640; // near 32bit max 2147483647
       &.profiler-no-controls .profiler-totals,
       &.profiler-no-controls .profiler-result:first-child .profiler-button,
       .profiler-controls {
-        -webkit-border-bottom-top-radius: $radius;
-        -moz-border-radius-topleft: $radius;
         border-top-left-radius: $radius;
       }
 

--- a/lib/html/includes.scss
+++ b/lib/html/includes.scss
@@ -56,7 +56,7 @@ $zindex: 2147483640; // near 32bit max 2147483647
   }
   .custom-fields-title {
     color: $textColor;
-    font: $normalFonts;
+    font-family: $normalFonts;
     font-size: 14px;
   }
   .ta-left  { text-align: left;  }

--- a/lib/mini_profiler/asset_version.rb
+++ b/lib/mini_profiler/asset_version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Rack
   class MiniProfiler
-    ASSET_VERSION = 'ec6d5541ecbc11a48798626c16a61342'
+    ASSET_VERSION = '35a79b300ab5afa978cb59af0b05e059'
   end
 end


### PR DESCRIPTION
This PR updates the CSS to remove these errors being flagged in Firefox:
<img width="631" alt="Screenshot at Aug 02 10-14-30" src="https://user-images.githubusercontent.com/22395/127879255-d392e1ad-41b5-404c-8c1c-4198d7d7dd0b.png">

I have tested this in the local demo app, I have also tested it in the https://github.com/o19s/quepid app by testing the branch:

```
gem 'rack-mini-profiler', git: 'https://github.com/epugh/rack-mini-profiler', branch: 'remove_old_css'
```