### PR TITLE
Add flamegraph_mode config option and query string parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ toggle_shortcut|Alt+P|Keyboard shortcut to toggle the mini_profiler's visibility
 start_hidden|`false`|`false` to make mini_profiler visible on page load.
 backtrace_threshold_ms|`0`|Minimum SQL query elapsed time before a backtrace is recorded.
 flamegraph_sample_rate|`0.5`|How often to capture stack traces for flamegraphs in milliseconds.
+flamegraph_mode|`:wall`|The [StackProf mode](https://github.com/tmm1/stackprof#all-options) to pass to `StackProf.run`.
 base_url_path|`'/mini-profiler-resources/'`|Path for assets; added as a prefix when naming assets and sought when responding to requests.
 collapse_results|`true`|If multiple timing results exist in a single page, collapse them till clicked.
 max_traces_to_show|20|Maximum number of mini profiler timing blocks to show on one page

--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -28,6 +28,7 @@ module Rack
           @authorization_mode     = :allow_all
           @backtrace_threshold_ms = 0
           @flamegraph_sample_rate = 0.5
+          @flamegraph_mode = :wall
           @storage_failure = Proc.new do |exception|
             if @logger
               @logger.warn("MiniProfiler storage failure: #{exception.message}")
@@ -70,7 +71,8 @@ module Rack
         :skip_schema_queries, :storage, :storage_failure, :storage_instance,
         :storage_options, :user_provider, :enable_advanced_debugging_tools,
         :skip_sql_param_names, :suppress_encoding, :max_sql_param_length,
-        :content_security_policy_nonce, :enable_hotwire_turbo_drive_support
+        :content_security_policy_nonce, :enable_hotwire_turbo_drive_support,
+        :flamegraph_mode
 
       # ui accessors
       attr_accessor :collapse_results, :max_traces_to_show, :position,

--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -362,8 +362,17 @@ module Rack
             else
               sample_rate = config.flamegraph_sample_rate
             end
+
+            mode_match_data = query_string.match(/flamegraph_mode=([a-zA-Z]+)/)
+
+            if mode_match_data && [:cpu, :wall, :object, :custom].include?(mode_match_data[1].to_sym)
+              mode = mode_match_data[1].to_sym
+            else
+              mode = config.flamegraph_mode
+            end
+
             flamegraph = StackProf.run(
-              mode: :wall,
+              mode: mode,
               raw: true,
               aggregate: false,
               interval: (sample_rate * 1000).to_i
@@ -658,6 +667,7 @@ Append the following to your query string:
   #{make_link "flamegraph", env} : a graph representing sampled activity (requires the stackprof gem).
   #{make_link "async-flamegraph", env} : store flamegraph data for this page and all its AJAX requests. Flamegraph links will be available in the mini-profiler UI (requires the stackprof gem).
   #{make_link "flamegraph&flamegraph_sample_rate=1", env}: creates a flamegraph with the specified sample rate (in ms). Overrides value set in config
+  #{make_link "flamegraph&flamegraph_mode=cpu", env}: creates a flamegraph with the specified mode (one of cpu, wall, object, or custom). Overrides value set in config
   #{make_link "flamegraph_embed", env} : a graph representing sampled activity (requires the stackprof gem), embedded resources for use on an intranet.
   #{make_link "trace-exceptions", env} : will return all the spots where your application raises exceptions
   #{make_link "analyze-memory", env} : will perform basic memory analysis of heap


### PR DESCRIPTION
With this change, the `:mode` passed to `StackProf.run` can be customized just like the sample rate.