### PR TITLE
Fix ArgumentError: comparison of String with 200 failed

### DIFF
--- a/lib/mini_profiler/profiler.rb
+++ b/lib/mini_profiler/profiler.rb
@@ -391,6 +391,7 @@ module Rack
           status, headers, body = [200, { 'Content-Type' => 'text/html' }, [blank_page_html.dup]]
         else
           status, headers, body = @app.call(env)
+          status = status.to_i
         end
       ensure
         trace.disable if trace


### PR DESCRIPTION
Casts the `status` to an integer before comparison.

### Issue
* #521

### Related PRs and Issues
* Issue #185 
* PR #186 