### PR TITLE
FEATURE: add cookie path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ backtrace_threshold_ms|`0`|Minimum SQL query elapsed time before a backtrace is 
 flamegraph_sample_rate|`0.5`|How often to capture stack traces for flamegraphs in milliseconds.
 flamegraph_mode|`:wall`|The [StackProf mode](https://github.com/tmm1/stackprof#all-options) to pass to `StackProf.run`.
 base_url_path|`'/mini-profiler-resources/'`|Path for assets; added as a prefix when naming assets and sought when responding to requests.
+cookie_path|`'/'`|Set-Cookie header path for profile cookie
 collapse_results|`true`|If multiple timing results exist in a single page, collapse them till clicked.
 max_traces_to_show|20|Maximum number of mini profiler timing blocks to show on one page
 html_container|`body`|The HTML container (as a jQuery selector) to inject the mini_profiler UI into

--- a/lib/mini_profiler/client_settings.rb
+++ b/lib/mini_profiler/client_settings.rb
@@ -74,7 +74,7 @@ module Rack
           settings["bt"] = @backtrace_level     if @backtrace_level
           settings["a"] = @allowed_tokens.join("|") if @allowed_tokens && MiniProfiler.request_authorized?
           settings_string = settings.map { |k, v| "#{k}=#{v}" }.join(",")
-          cookie = { value: settings_string, path: '/', httponly: true }
+          cookie = { value: settings_string, path: MiniProfiler.config.cookie_path, httponly: true }
           cookie[:secure] = true if @request.ssl?
           cookie[:same_site] = 'Lax'
           Rack::Utils.set_cookie_header!(headers, COOKIE_NAME, cookie)
@@ -83,7 +83,7 @@ module Rack
 
       def discard_cookie!(headers)
         if @cookie
-          Rack::Utils.delete_cookie_header!(headers, COOKIE_NAME, path: '/')
+          Rack::Utils.delete_cookie_header!(headers, COOKIE_NAME, path: MiniProfiler.config.cookie_path)
         end
       end
 

--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -17,6 +17,7 @@ module Rack
         new.instance_eval {
           @auto_inject      = true # automatically inject on every html page
           @base_url_path    = "/mini-profiler-resources/".dup
+          @cookie_path      = "/".dup
           @disable_caching  = true
           # called prior to rack chain, to ensure we are allowed to profile
           @pre_authorize_cb = lambda { |env| true }
@@ -66,7 +67,7 @@ module Rack
 
       attr_accessor :authorization_mode, :auto_inject, :backtrace_ignores,
         :backtrace_includes, :backtrace_remove, :backtrace_threshold_ms,
-        :base_url_path, :disable_caching, :enabled,
+        :base_url_path, :cookie_path, :disable_caching, :enabled,
         :flamegraph_sample_rate, :logger, :pre_authorize_cb, :skip_paths,
         :skip_schema_queries, :storage, :storage_failure, :storage_instance,
         :storage_options, :user_provider, :enable_advanced_debugging_tools,

--- a/spec/lib/client_settings_spec.rb
+++ b/spec/lib/client_settings_spec.rb
@@ -40,6 +40,21 @@ describe Rack::MiniProfiler::ClientSettings do
       expect(hash).not_to eq({})
     end
 
+    it 'sets cookie path to / by default' do
+      @settings.disable_profiling = false
+      hash = {}
+      @settings.write!(hash)
+      expect(hash["Set-Cookie"]).to include("path=/;")
+    end
+
+    it 'should correctly set cookie with correct path' do
+      Rack::MiniProfiler.config.cookie_path = '/test'
+      @settings.disable_profiling = false
+      hash = {}
+      @settings.write!(hash)
+      expect(hash["Set-Cookie"]).to include("path=/test;")
+    end
+
     it 'writes auth token for authorized reqs' do
       Rack::MiniProfiler.config.authorization_mode = :allow_authorized
       Rack::MiniProfiler.authorize_request


### PR DESCRIPTION
Adds cookie path support for sites hosting cookies on subfolder paths.

Without this, other set-cookie headers' paths may be unable to set paths.