### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.0.0 - 2022-02-24
+
+- PERF: Improve snapshots page performance (#518) (introduces breaking changes to the API of `AbstractStore`, `MemoryStore` and `RedisStore`, and removes the `snapshots_limit` config option.)
+
 ## 2.3.4 - 2022-02-23
 
 - [FEATURE] Add cookie path support for subfolder sites

--- a/lib/mini_profiler/version.rb
+++ b/lib/mini_profiler/version.rb
@@ -2,7 +2,7 @@
 
 module Rack
   class MiniProfiler
-    VERSION = '2.3.4'
+    VERSION = '3.0.0'
     SOURCE_CODE_URI = 'https://github.com/MiniProfiler/rack-mini-profiler'
   end
 end


### PR DESCRIPTION
Bumping the major version because 3e6f7e5 introduces a number of breaking changes to the abstract, memory and redis stores API, and also replaces the `snapshot_limit` config option with `max_snapshot_groups` and `max_snapshots_per_group`. 