### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.0", "2.7", "2.6", "2.5"]
+        ruby: ["3.1", "3.0", "2.7", "2.6"]
         redis: ["5.x"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "2.7", "2.6", "2.5"]
+        ruby: ["3.1", "3.0", "2.7", "2.6", "2.5"]
         redis: ["5.x"]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR just adds Ruby 3.1 to the CI matrix.