### PR TITLE
Update gem and docs to ref Ruby 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'http://rubygems.org'
-ruby '>= 2.4.0'
+ruby '>= 2.5.0'
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'http://rubygems.org'
-ruby '>= 2.5.0'
+ruby '>= 2.6.0'
 
 gemspec
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you feel like taking on any of this start an issue and update us on your prog
 
 ## Installation
 
-Install/add to Gemfile in Ruby 2.4+
+Install/add to Gemfile in Ruby 2.5+
 
 ```ruby
 gem 'rack-mini-profiler'
@@ -168,7 +168,7 @@ export RACK_MINI_PROFILER_PATCH="false"
 
 To generate [flamegraphs](http://samsaffron.com/archive/2013/03/19/flame-graphs-in-ruby-miniprofiler), add the [**stackprof**](https://rubygems.org/gems/stackprof) gem to your Gemfile.
 
-Then, to view the flamegraph as a direct HTML response from your request, just visit any page in your app with `?pp=flamegraph` appended to the URL. 
+Then, to view the flamegraph as a direct HTML response from your request, just visit any page in your app with `?pp=flamegraph` appended to the URL.
 
 Conversely, if you want your regular response instead (which is specially useful for JSON and/or XHR requests), just append the `?pp=async-flamegraph` parameter to your request/fetch URL; the request will then return as normal, and the flamegraph data will be stored for later *async* viewing, both for this request and for all subsequent requests made by this page (based on the `REFERER` header). For viewing these async flamegraphs, use the 'flamegraph' link that will appear inside the MiniProfiler UI for these requests.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you feel like taking on any of this start an issue and update us on your prog
 
 ## Installation
 
-Install/add to Gemfile in Ruby 2.5+
+Install/add to Gemfile in Ruby 2.6+
 
 ```ruby
 gem 'rack-mini-profiler'

--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     "CHANGELOG.md"
   ]
   s.add_runtime_dependency 'rack', '>= 1.2.0'
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.metadata = {
     'source_code_uri' => Rack::MiniProfiler::SOURCE_CODE_URI,

--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     "CHANGELOG.md"
   ]
   s.add_runtime_dependency 'rack', '>= 1.2.0'
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.6.0'
 
   s.metadata = {
     'source_code_uri' => Rack::MiniProfiler::SOURCE_CODE_URI,


### PR DESCRIPTION
As noted in #528 `rack-mini-profiler` is no longer compatible with Ruby 2.4. This PR simply updates the README and gemspec to reference that