### PR TITLE
show connection time in Net::HTTP requests

### DIFF
--- a/lib/patches/net_patches.rb
+++ b/lib/patches/net_patches.rb
@@ -4,6 +4,18 @@ if (defined?(Net) && defined?(Net::HTTP))
 
   if defined?(Rack::MINI_PROFILER_PREPEND_NET_HTTP_PATCH)
     module NetHTTPWithMiniProfiler
+      def connect()
+        if proxy? then
+          conn_addr = proxy_address
+          conn_port = proxy_port
+        else
+          conn_addr = conn_address
+          conn_port = port
+        end
+        Rack::MiniProfiler.step("Net::HTTP Connect #{conn_addr}:#{conn_port}") do
+          super
+        end
+      end
       def request(request, *args, &block)
         Rack::MiniProfiler.step("Net::HTTP #{request.method} #{request.path}") do
           super
@@ -13,6 +25,20 @@ if (defined?(Net) && defined?(Net::HTTP))
     Net::HTTP.prepend(NetHTTPWithMiniProfiler)
   else
     Net::HTTP.class_eval do
+      def connect_with_mini_profiler()
+        if proxy? then
+          conn_addr = proxy_address
+          conn_port = proxy_port
+        else
+          conn_addr = conn_address
+          conn_port = port
+        end
+        Rack::MiniProfiler.step("Net::HTTP Connect #{conn_addr}:#{conn_port}") do
+          connect_without_mini_profiler()
+        end
+      end
+      alias connect_without_mini_profiler connect
+      alias connect connect_with_mini_profiler
       def request_with_mini_profiler(*args, &block)
         request = args[0]
         Rack::MiniProfiler.step("Net::HTTP #{request.method} #{request.path}") do


### PR DESCRIPTION
This separates out the time needed to connect to the server, if any, from the time needed to make the request and receive the response.