### PR TITLE
Require Rails 6.0+

### DIFF
--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+gem "rails", ">= 6.0"
+
 require 'fileutils'
 require_relative './railtie_methods'
 
@@ -154,13 +156,7 @@ module Rack::MiniProfilerRails
       return false
     end
 
-    if ::Rails.version >= "5.0.0"
-      ::Rails.configuration.public_file_server.enabled
-    elsif ::Rails.version >= "4.2.0"
-      ::Rails.configuration.serve_static_files
-    else
-      ::Rails.configuration.serve_static_assets
-    end
+    ::Rails.configuration.public_file_server.enabled
   end
 
   class Railtie < ::Rails::Railtie

--- a/lib/rack-mini-profiler.rb
+++ b/lib/rack-mini-profiler.rb
@@ -32,6 +32,4 @@ require 'mini_profiler/profiler'
 require 'patches/sql_patches'
 require 'patches/net_patches'
 
-if defined?(::Rails) && defined?(::Rails::VERSION) && ::Rails::VERSION::MAJOR.to_i >= 3
-  require 'mini_profiler_rails/railtie'
-end
+require 'mini_profiler_rails/railtie' if defined?(::Rails)


### PR DESCRIPTION
Use bundler to require Rails 6.0 or greater as a peer dependency. We should use Rails 6+ here because that is what's currently supported in the Ruby on Rails maintenance policy.

Also looks like https://github.com/MiniProfiler/rack-mini-profiler/pull/539 can be merged with this change. Rails 2.x support will be dropped. If a developer wants to reference this for an older version of the profiler, they can switch to the version tag.

For reference, this approach is inspired by how we manage peer deps in Rails: https://github.com/rails/rails/blob/dcd8f37bc63d46f28aa55e6891b03a0b0b73e497/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L6