### PR TITLE
Deprecate rack_profiler:install in favour of rack_mini_profiler:install

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ be loaded outright, and an attempt to re-initialize it manually will raise an ex
 Then run the generator which will set up rack-mini-profiler in development:
 
 ```bash
-bundle exec rails g rack_profiler:install
+bundle exec rails g rack_mini_profiler:install
 ```
 
 #### Rack Builder

--- a/lib/generators/rack_mini_profiler/USAGE
+++ b/lib/generators/rack_mini_profiler/USAGE
@@ -1,0 +1,9 @@
+Description:
+    Generates an initializer for rack-mini-profiler. Use an initializer when manually
+    requiring rack-mini-profiler in your application (using require: false in your Gemfile).
+
+Example:
+    `bin/rails generate rack_mini_profiler:install`
+
+    This generates a an initializer that requires and initializes
+    rack-mini-profiler in development mode.

--- a/lib/generators/rack_mini_profiler/install_generator.rb
+++ b/lib/generators/rack_mini_profiler/install_generator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module RackMiniProfiler
+  module Generators
+    class InstallGenerator < ::Rails::Generators::Base
+      source_root File.expand_path("templates", __dir__)
+
+      def create_initializer_file
+        copy_file "rack_mini_profiler.rb", "config/initializers/rack_mini_profiler.rb"
+      end
+    end
+  end
+end

--- a/lib/generators/rack_mini_profiler/templates/rack_mini_profiler.rb
+++ b/lib/generators/rack_mini_profiler/templates/rack_mini_profiler.rb
@@ -3,6 +3,6 @@
 if Rails.env.development?
   require "rack-mini-profiler"
 
-  # initialization is skipped so trigger it
+  # The initializer was required late, so initialize it manually.
   Rack::MiniProfilerRails.initialize!(Rails.application)
 end

--- a/lib/generators/rack_profiler/install_generator.rb
+++ b/lib/generators/rack_profiler/install_generator.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
+require "generators/rack_mini_profiler/install_generator"
+
 module RackProfiler
   module Generators
-    class InstallGenerator < ::Rails::Generators::Base
-      source_root File.expand_path("templates", __dir__)
+    class InstallGenerator < RackMiniProfiler::Generators::InstallGenerator
+      source_root File.expand_path("../rack_mini_profiler/templates", __dir__)
 
       def create_initializer_file
-        copy_file "rack_profiler.rb", "config/initializers/rack_profiler.rb"
+        warn("bin/rails generate rack_profiler:install is deprecated. Please use rack_mini_profiler:install instead.")
+        super
       end
     end
   end


### PR DESCRIPTION
The gem's name and install generator should be the same.

This deprecates the current generator in favour of a more appropriately named one. It also updates copy on the initializer comments and usage clarifying what it is doing and when to use an initializer. Behaviour is changed for the install generator to always generate a `rack_mini_profiler.rb` initializer instead, but I think that's acceptable if we want to rename the generator.