### PR TITLE
Use RSpec 3.12

### DIFF
--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'dalli'
-  s.add_development_dependency 'rspec', '~> 3.6.0'
+  s.add_development_dependency 'rspec', '~> 3.12.0'
   s.add_development_dependency 'redis'
   s.add_development_dependency 'sassc'
   s.add_development_dependency 'stackprof'


### PR DESCRIPTION
Fixes ERB warnings when running tests:

```
> bundle exec rspec
/home/runner/work/rack-mini-profiler/rack-mini-profiler/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.[6](https://github.com/MiniProfiler/rack-mini-profiler/actions/runs/4128280759/jobs/7132528979#step:6:7).0/lib/rspec/core/configuration_options.rb:1[7](https://github.com/MiniProfiler/rack-mini-profiler/actions/runs/4128280759/jobs/7132528979#step:6:8)1: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/home/runner/work/rack-mini-profiler/rack-mini-profiler/vendor/bundle/ruby/3.1.0/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
...
```