### PR TITLE
Autoload sotrage adapters

### DIFF
--- a/lib/mini_profiler.rb
+++ b/lib/mini_profiler.rb
@@ -27,11 +27,11 @@ module Rack
       end
 
       def resources_root
-        @resources_root ||= ::File.expand_path("../../html", __FILE__)
+        @resources_root ||= ::File.expand_path("../html", __FILE__)
       end
 
       def share_template
-        @share_template ||= ERB.new(::File.read(::File.expand_path("../html/share.html", ::File.dirname(__FILE__))))
+        @share_template ||= ERB.new(::File.read(::File.expand_path("html/share.html", ::File.dirname(__FILE__))))
       end
 
       def current
@@ -773,7 +773,7 @@ This is the help menu of the <a href='#{Rack::MiniProfiler::SOURCE_CODE_URI}'>ra
       end
 
       # TODO : cache this snippet
-      script = ::File.read(::File.expand_path('../html/profile_handler.js', ::File.dirname(__FILE__)))
+      script = ::File.read(::File.expand_path('html/profile_handler.js', ::File.dirname(__FILE__)))
       # replace the variables
       settings.each do |k, v|
         regex = Regexp.new("\\{#{k.to_s}\\}")

--- a/lib/mini_profiler.rb
+++ b/lib/mini_profiler.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
 require 'cgi'
+require 'json'
+require 'erb'
+
+require 'mini_profiler/timer_struct'
+require 'mini_profiler/storage'
+require 'mini_profiler/config'
+require 'mini_profiler/profiling_methods'
+require 'mini_profiler/context'
+require 'mini_profiler/client_settings'
+require 'mini_profiler/gc_profiler'
+require 'mini_profiler/snapshots_transporter'
 
 module Rack
   class MiniProfiler

--- a/lib/mini_profiler/storage.rb
+++ b/lib/mini_profiler/storage.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'mini_profiler/storage/abstract_store'
+require 'mini_profiler/storage/memcache_store'
+require 'mini_profiler/storage/memory_store'
+require 'mini_profiler/storage/redis_store'
+require 'mini_profiler/storage/file_store'

--- a/lib/mini_profiler/storage.rb
+++ b/lib/mini_profiler/storage.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
-require 'mini_profiler/storage/abstract_store'
-require 'mini_profiler/storage/memcache_store'
-require 'mini_profiler/storage/memory_store'
-require 'mini_profiler/storage/redis_store'
-require 'mini_profiler/storage/file_store'
+
+module Rack
+  class MiniProfiler
+    autoload(:AbstractStore, 'mini_profiler/storage/abstract_store')
+    autoload(:MemcacheStore, 'mini_profiler/storage/memcache_store')
+    autoload(:MemoryStore, 'mini_profiler/storage/memory_store')
+    autoload(:RedisStore, 'mini_profiler/storage/redis_store')
+    autoload(:FileStore, 'mini_profiler/storage/file_store')
+  end
+end

--- a/lib/mini_profiler/storage/file_store.rb
+++ b/lib/mini_profiler/storage/file_store.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'securerandom'
+
 module Rack
   class MiniProfiler
     class FileStore < AbstractStore

--- a/lib/mini_profiler/storage/memcache_store.rb
+++ b/lib/mini_profiler/storage/memcache_store.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'dalli'
+
 module Rack
   class MiniProfiler
     class MemcacheStore < AbstractStore
@@ -8,7 +10,6 @@ module Rack
       MAX_RETRIES        = 10
 
       def initialize(args = nil)
-        require 'dalli' unless defined? Dalli
         args ||= {}
 
         @prefix = args[:prefix] || "MPMemcacheStore"

--- a/lib/mini_profiler/storage/memory_store.rb
+++ b/lib/mini_profiler/storage/memory_store.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'securerandom'
+
 module Rack
   class MiniProfiler
     class MemoryStore < AbstractStore

--- a/lib/mini_profiler/storage/redis_store.rb
+++ b/lib/mini_profiler/storage/redis_store.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'digest'
+require 'securerandom'
 
 module Rack
   class MiniProfiler

--- a/lib/mini_profiler/storage/redis_store.rb
+++ b/lib/mini_profiler/storage/redis_store.rb
@@ -2,6 +2,7 @@
 
 require 'digest'
 require 'securerandom'
+require 'redis'
 
 module Rack
   class MiniProfiler
@@ -271,7 +272,6 @@ unviewed_ids: #{get_unviewed_ids(user)}
 
       def redis
         @redis_connection ||= begin
-          require 'redis' unless defined? Redis
           Redis.new(@args)
         end
       end

--- a/lib/mini_profiler/timer_struct.rb
+++ b/lib/mini_profiler/timer_struct.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'mini_profiler/timer_struct/base'
+require 'mini_profiler/timer_struct/page'
+require 'mini_profiler/timer_struct/sql'
+require 'mini_profiler/timer_struct/custom'
+require 'mini_profiler/timer_struct/client'
+require 'mini_profiler/timer_struct/request'

--- a/lib/mini_profiler/timer_struct/base.rb
+++ b/lib/mini_profiler/timer_struct/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 module Rack
   class MiniProfiler
     module TimerStruct

--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'erb'
+
 module Rack
   class MiniProfiler
 

--- a/lib/rack-mini-profiler.rb
+++ b/lib/rack-mini-profiler.rb
@@ -1,34 +1,10 @@
 # frozen_string_literal: true
 
-require 'erb'
-require 'json'
-require 'timeout'
-require 'thread'
-require 'securerandom'
-
 require 'mini_profiler/version'
 require 'mini_profiler/asset_version'
 
-require 'mini_profiler/timer_struct/base'
-require 'mini_profiler/timer_struct/page'
-require 'mini_profiler/timer_struct/sql'
-require 'mini_profiler/timer_struct/custom'
-require 'mini_profiler/timer_struct/client'
-require 'mini_profiler/timer_struct/request'
-
-require 'mini_profiler/storage/abstract_store'
-require 'mini_profiler/storage/memcache_store'
-require 'mini_profiler/storage/memory_store'
-require 'mini_profiler/storage/redis_store'
-require 'mini_profiler/storage/file_store'
-
-require 'mini_profiler/config'
-require 'mini_profiler/profiling_methods'
-require 'mini_profiler/context'
-require 'mini_profiler/client_settings'
-require 'mini_profiler/gc_profiler'
-require 'mini_profiler/snapshots_transporter'
 require 'mini_profiler'
+
 require 'patches/sql_patches'
 require 'patches/net_patches'
 

--- a/lib/rack-mini-profiler.rb
+++ b/lib/rack-mini-profiler.rb
@@ -28,7 +28,7 @@ require 'mini_profiler/context'
 require 'mini_profiler/client_settings'
 require 'mini_profiler/gc_profiler'
 require 'mini_profiler/snapshots_transporter'
-require 'mini_profiler/profiler'
+require 'mini_profiler'
 require 'patches/sql_patches'
 require 'patches/net_patches'
 

--- a/spec/integration/railtie_methods_spec.rb
+++ b/spec/integration/railtie_methods_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'securerandom'
 require 'rack/test'
 require File.expand_path('../../../lib/mini_profiler_rails/railtie_methods', __FILE__)
 


### PR DESCRIPTION
Autoloads storage adapters because it is unnecessary to load storage
adapters you won't use. Autoload lets us defer loading the file until it
is referenced, so that we can require storage dependencies normally and
expect them to load when called.

Depends on https://github.com/MiniProfiler/rack-mini-profiler/pull/551. I can't make a PR to this repo if my merge target is on my fork, so this will have to do for now.