### PR TITLE
Update Readme for Specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,8 +486,8 @@ Make sure to prepend `bundle exec` before any Rake tasks you run.
 You need Memcached and Redis services running for the specs.
 
 ```
-$ rake build
-$ rake spec
+$ bundle exec rake build
+$ bundle exec rake spec
 ```
 
 ## Licence


### PR DESCRIPTION
`rake build` and `rake spec` doesn't work without prepending `bundle exec`:
```
keshavbiswa@Keshavs-MacBook-Pro rack-mini-profiler % rake build
rake aborted!
LoadError: cannot load such file -- rspec/core
(See full trace by running task with --trace)
```