### PR TITLE
Add controller_name to Description

### DIFF
--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -75,7 +75,8 @@ module Rack::MiniProfilerRails
         next if !should_measure?
 
         current = Rack::MiniProfiler.current
-        description = "Executing action: #{payload[:action]}"
+        controller_name = payload[:controller].sub(/Controller\z/, '').downcase
+        description = "Executing: #{controller_name}##{payload[:action]}"
         Thread.current[get_key(payload)] = current.current_timer
         Rack::MiniProfiler.current.current_timer = current.current_timer.add_child(description)
       end


### PR DESCRIPTION
This is an enhancement based on #561 .

Controller without namespace will now render the controller name:

![Screenshot 2023-04-05 at 10 23 53 PM](https://user-images.githubusercontent.com/27268721/230150328-e02f65c0-cdbe-4556-b2a6-6659f556747f.png)

Controller with namespaces will render the namespaced controller name:

![Screenshot 2023-04-05 at 10 24 32 PM](https://user-images.githubusercontent.com/27268721/230150490-430cf68d-efb4-4288-8599-88c7eb3ab47d.png)

PS: Need help with the tests!

cc: @nateberkopec 
