### PR TITLE
Choose your RMP action via the X-Rack-Mini-Profiler header

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ export RACK_MINI_PROFILER_PATCH_NET_HTTP="false"
 
 To generate [flamegraphs](http://samsaffron.com/archive/2013/03/19/flame-graphs-in-ruby-miniprofiler), add the [**stackprof**](https://rubygems.org/gems/stackprof) gem to your Gemfile.
 
-Then, to view the flamegraph as a direct HTML response from your request, just visit any page in your app with `?pp=flamegraph` appended to the URL.
+Then, to view the flamegraph as a direct HTML response from your request, just visit any page in your app with `?pp=flamegraph` appended to the URL, or add the header `X-Rack-Mini-Profiler` to the request with the value `flamegraph`.
 
 Conversely, if you want your regular response instead (which is specially useful for JSON and/or XHR requests), just append the `?pp=async-flamegraph` parameter to your request/fetch URL; the request will then return as normal, and the flamegraph data will be stored for later *async* viewing, both for this request and for all subsequent requests made by this page (based on the `REFERER` header). For viewing these async flamegraphs, use the 'flamegraph' link that will appear inside the MiniProfiler UI for these requests.
 

--- a/lib/mini_profiler/views.rb
+++ b/lib/mini_profiler/views.rb
@@ -164,6 +164,8 @@ module Rack
                 #{make_link "flamegraph_embed", env} : a graph representing sampled activity (requires the stackprof gem), embedded resources for use on an intranet.
                 #{make_link "trace-exceptions", env} : will return all the spots where your application raises exceptions
                 #{make_link "analyze-memory", env} : will perform basic memory analysis of heap
+
+                All features can also be accessed by adding the X-Rack-Mini-Profiler header to the request, with any of the values above (e.g. 'X-Rack-Mini-Profiler: flamegraph')
               </pre>
             </body>
           </html>

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -376,6 +376,14 @@ describe Rack::MiniProfiler do
         expect(last_response.body).to include('QUERY_STRING')
         expect(last_response.body).to include('CONTENT_LENGTH')
       end
+
+      it 'works via HTTP header' do 
+        Rack::MiniProfiler.config.enable_advanced_debugging_tools = true
+        get '/html', nil, { 'HTTP_X_RACK_MINI_PROFILER' => 'env' }
+
+        expect(last_response.body).to include('QUERY_STRING')
+        expect(last_response.body).to include('CONTENT_LENGTH')
+      end 
     end
   end
 
@@ -413,6 +421,11 @@ describe Rack::MiniProfiler do
       get '/html?pp=profile-gc'
       expect(last_response.header['Content-Type']).to include('text/plain')
     end
+
+    it "should return a report when an HTTP header is used" do 
+      get '/html', nil, { 'HTTP_X_RACK_MINI_PROFILER' => 'profile-gc' }
+      expect(last_response.header['Content-Type']).to include('text/plain')
+    end 
   end
 
   describe 'error handling when storage_instance fails to save' do
@@ -652,6 +665,13 @@ describe Rack::MiniProfiler do
       get "#{base_url}results?id=%22%3E%3Cqss%3E&group=groupdoesnotexist"
       expect(last_response.status).to eq(404)
       expect(last_response.body).to eq("Snapshot with id '&quot;&gt;&lt;qss&gt;' not found"), "id should be escaped to prevent XSS"
+    end
+  end
+  
+  describe 'when triggering via HTTP header' do
+    it 'can trigger the help option via an HTTP header' do
+      get '/html', nil, { 'HTTP_X_RACK_MINI_PROFILER' => 'help' }
+      expect(last_response.body).to include('This is the help menu')
     end
   end
 end


### PR DESCRIPTION
Use case: sometimes query parameters are not propagated through infrastructure, but request headers are (GraphQL, in our case).

