### PR TITLE
Fix: account for vertical position bottom in placement of popup

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -401,9 +401,10 @@ var _MiniProfiler = (function() {
     var px = button.offsetTop - 1,
       // position next to the button we clicked
       windowHeight = window.innerHeight,
-      maxHeight = windowHeight - px - 40; // make sure the popup doesn't extend below the fold
+      maxHeight = windowHeight - px - 40, // make sure the popup doesn't extend below the fold
+      pxVertical = options.renderVerticalPosition === 'bottom' ? button.offsetParent.clientHeight - 21 - px : px;
 
-    popup.style[options.renderVerticalPosition] = "".concat(px, "px");
+    popup.style[options.renderVerticalPosition] = "".concat(pxVertical, "px");
     popup.style.maxHeight = "".concat(maxHeight, "px");
     popup.style[options.renderHorizontalPosition] = "".concat(
       button.offsetWidth - 3,


### PR DESCRIPTION
use parent height to determine bottom style property for the popup as we start from the bottom to position and not the top. Also, take button height (`21px`) into account so it's positioned at the bottom.

See #580 for more information.