### PR TITLE
[BUG] Support non-webpacker environments

### DIFF
--- a/lib/mini_profiler_rails/railtie_methods.rb
+++ b/lib/mini_profiler_rails/railtie_methods.rb
@@ -52,7 +52,7 @@ module Rack::MiniProfilerRailsMethods
   end
 
   def get_webpacker_assets_path
-    if defined?(Webpacker) && Webpacker.config.config_path.exist?
+    if defined?(Webpacker) && Webpacker.try(:config)&.config_path&.exist?
       Webpacker.config.public_output_path.to_s.gsub(Webpacker.config.public_path.to_s, "")
     end
   end


### PR DESCRIPTION
Hi all,

I finally updating my local copy of rack-mini-profiler. (it has been since 2018 - sorry)

Ran into this problem running rails 6.1.

It may be because our rails ui is running as an engine, or because I load rack-mini-profiler in an initializer instead of the standard `gem 'rack-mini-profiler'` syntax. (hoping this new code base will mean I can drop that too)

If you want me to code this up differently, let me know.

---

Webpacker can be defined, but not configured.

### Problem

```
lib/mini_profiler_rails/railtie_methods.rb:55:in `get_webpacker_assets_path': undefined method `config' for Webpacker:Module (NoMethodError)
Did you mean?  concerning
	from lib/mini_profiler_rails/railtie.rb:33:in `initialize!'
```

### Solution

Treating it like webpacker is not present.

- Ensure the full chain is available