### PR TITLE
[BUG] Default to ActiveSupport::Notifications for pg and mysql2

### DIFF
--- a/lib/patches/sql_patches.rb
+++ b/lib/patches/sql_patches.rb
@@ -30,8 +30,8 @@ class SqlPatches
   def self.sql_patches
     patches = []
 
-    patches << 'mysql2' if defined?(Mysql2::Client) && Mysql2::Client.class == Class
-    patches << 'pg' if defined?(PG::Result) && PG::Result.class == Class
+    patches << 'mysql2' if defined?(Mysql2::Client) && Mysql2::Client.class == Class && patch_rails?
+    patches << 'pg' if defined?(PG::Result) && PG::Result.class == Class && patch_rails?
     patches << 'oracle_enhanced' if defined?(ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter) && ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter.class == Class &&
                                     SqlPatches.correct_version?('~> 1.5.0', ActiveRecord::ConnectionAdapters::OracleEnhancedAdapter) &&
                                     patch_rails?


### PR DESCRIPTION
Before
======

Per https://github.com/MiniProfiler/rack-mini-profiler/pull/418, Oracle defaults to using `ActiveSupport::Notifications`. Setting `patch_rails?` skips the notifications and uses rails.

`SqlPatches.sql_patches` ignores that setting and always returns ["pg"] for postgres. So it always patches Postgres, and does not have a way to leverage `ActiveSupport::Notifications`. The same holds with MySql.

After
=====

Like Oracle, Postgres and MySql are checking with `patch_rails?` to determine if the rails code should be patched.
`SqlPatches.sql_patches` returns `[]` for postgres and mysql.
