### PR TITLE
Use profile parameter config for framegraph ability

### DIFF
--- a/lib/mini_profiler.rb
+++ b/lib/mini_profiler.rb
@@ -359,7 +359,7 @@ module Rack
         # Prevent response body from being compressed
         env['HTTP_ACCEPT_ENCODING'] = 'identity' if config.suppress_encoding
 
-        if query_string =~ /pp=(async-)?flamegraph/ || env['HTTP_REFERER'] =~ /pp=async-flamegraph/
+        if query_string =~ /#{@config.profile_parameter}=(async-)?flamegraph/ || env['HTTP_REFERER'] =~ /#{@config.profile_parameter}=async-flamegraph/
           if defined?(StackProf) && StackProf.respond_to?(:run)
             # do not sully our profile with mini profiler timings
             current.measure = false


### PR DESCRIPTION
Profile parameter got config-able with https://github.com/MiniProfiler/rack-mini-profiler/pull/553, but the framegraph ability still depends on `pp`. I think it should use `@config.profile_parameter`.