### PR TITLE
[Enhancement] Capture the number of rows instantiated

### DIFF
--- a/lib/mini_profiler/profiling_methods.rb
+++ b/lib/mini_profiler/profiling_methods.rb
@@ -17,6 +17,10 @@ module Rack
         )
       end
 
+      def report_reader_duration(elapsed_ms, row_count = nil, class_name = nil)
+        current&.current_timer&.report_reader_duration(elapsed_ms, row_count, class_name)
+      end
+
       def start_step(name)
         return unless current
         parent_timer          = current.current_timer

--- a/lib/mini_profiler/timer_struct/request.rb
+++ b/lib/mini_profiler/timer_struct/request.rb
@@ -125,6 +125,12 @@ module Rack
           end
         end
 
+        # please call SqlTiming#report_reader_duration instead
+        def report_reader_duration(elapsed_ms, row_count = nil, class_name = nil)
+          last_time = self[:sql_timings]&.last
+          last_time&.report_reader_duration(elapsed_ms, row_count, class_name)
+        end
+
         def add_custom(type, elapsed_ms, page)
           TimerStruct::Custom.new(type, elapsed_ms, page, self).tap do |timer|
             timer[:parent_timing_id] = self[:id]

--- a/lib/mini_profiler/timer_struct/sql.rb
+++ b/lib/mini_profiler/timer_struct/sql.rb
@@ -51,12 +51,14 @@ module Rack
           )
         end
 
-        def report_reader_duration(elapsed_ms)
+        def report_reader_duration(elapsed_ms, row_count = nil, class_name = nil)
           return if @reported
           @reported = true
           self[:duration_milliseconds]                += elapsed_ms
           @parent[:sql_timings_duration_milliseconds] += elapsed_ms
           @page[:duration_milliseconds_in_sql]        += elapsed_ms
+          self[:row_count] = self[:row_count].to_i + row_count if row_count
+          self[:class_name] = class_name if class_name
         end
 
         def trim_binds(binds)

--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -114,6 +114,16 @@ module Rack::MiniProfilerRails
             Rack::MiniProfiler.binds_to_params(payload[:binds])
           )
         end
+
+        subscribe("instantiation.active_record") do |name, start, finish, id, payload|
+          next if !should_measure?
+
+          Rack::MiniProfiler.report_reader_duration(
+            (finish - start) * 1000,
+            payload[:record_count],
+            payload[:class_name]
+          )
+        end
       end
     end
     @already_initialized = true


### PR DESCRIPTION
## Goal

This uses active support notifications to capture the number of active record objects instantiated.

## Useful?

If you just look at the number of queries, doing a bunch of outer joins looks like a great optimization.

But if you take into account the amount of data brought back, it keeps that over simplification in check.

I have been using this for >7 years and it is a key metric for me.
So I'm putting it out there and see if it is useful to others, as well.

## Shortcoming

#### This only captures instantiation

`Model.where(:category => 5).limit(20).select(:name)` - captures
`Model.where(:category => 5).limit(20).pluck(:name)` - doesn't capture

Since instantiations are a majority of our use cases, I've only seen a handful of cases where the `pluck` misrepresented a PR or an issue.

#### This is only for active record notifications

I only implemented this for `ActiveSupport::Notifications`. It could be done for the others, but I'd prefer to gauge demand before implementing this for every patch configuration.

#### This isn't in the ui

I use the command line to view the results, so I haven't coded this into the ui.
If that is needed, would like a little help.