### PR TITLE
Include configured base path in speedscope iframe URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- [FIX] Include configured base path in speedscope iframe URL
+
 ## 3.1.0 - 2023-04-11
 
 - [FEATURE] The query parameter that RMP uses (by default, pp) is now configurable [#553](https://github.com/MiniProfiler/rack-mini-profiler/pull/553)

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -162,6 +162,12 @@ describe Rack::MiniProfiler do
       expect(last_response.body).to include("<title>Rack::MiniProfiler Flamegraph</title>")
       expect(last_response.body).to include("var graph = {")
 
+      # Should have correct iframe URL when the base URL changes
+      get "/mini-profiler-resources/flamegraph?id=#{id}", nil, { 'SCRIPT_NAME' => '/my/base/url' }
+      expect(last_response).to be_ok
+      expect(last_response.body).to include("<title>Rack::MiniProfiler Flamegraph</title>")
+      expect(last_response.body).to include("iframeUrl = '/my/base/url/mini-profiler-resources/speedscope/")
+
       # Should not store/return flamegraph for regular requests
       get '/html'
       expect(last_response).to be_ok


### PR DESCRIPTION
When rack-mini-profiler was used under a different base URL (e.g. when deployed in a Rails app with `relative_url_root` configured), the stackprof iframe URL was missing the base path. This commit fixes the path for the flamegraph by sharing logic with the `#get_profile_script` method, and adds a spec.