### PR TITLE
Check if memcached is running during memcache spec, and fail if not running

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+# convenient way to start memcached for specs that need it: docker-compose up -d
+services:
+  memcached:
+    image: memcached
+    ports:
+      - "11211:11211"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,0 @@
-# convenient way to start memcached for specs that need it: docker-compose up -d
-services:
-  memcached:
-    image: memcached
-    ports:
-      - "11211:11211"

--- a/lib/mini_profiler/storage/memcache_store.rb
+++ b/lib/mini_profiler/storage/memcache_store.rb
@@ -18,6 +18,15 @@ module Rack
         @expires_in_seconds = args[:expires_in] || EXPIRES_IN_SECONDS
       end
 
+      def alive?
+        begin
+          @client.alive!
+          true
+        rescue Dalli::RingError
+          false
+        end
+      end
+
       def save(page_struct)
         @client.set("#{@prefix}#{page_struct[:id]}", Marshal::dump(page_struct), @expires_in_seconds)
       end

--- a/spec/lib/storage/memcache_store_spec.rb
+++ b/spec/lib/storage/memcache_store_spec.rb
@@ -7,7 +7,7 @@ describe Rack::MiniProfiler::MemcacheStore do
     before do
       @store = Rack::MiniProfiler::MemcacheStore.new
       unless @store.alive?
-        fail 'Memcached does not appear to be running on localhost:11211. Use your favorite package manage to install and run it, or `docker-compose up -d`'
+        fail 'Memcached does not appear to be running on localhost:11211. Use your favorite package manager to install and run it, use Docker with: `docker run -it --rm memcached`'
       end
     end
 

--- a/spec/lib/storage/memcache_store_spec.rb
+++ b/spec/lib/storage/memcache_store_spec.rb
@@ -6,6 +6,9 @@ describe Rack::MiniProfiler::MemcacheStore do
 
     before do
       @store = Rack::MiniProfiler::MemcacheStore.new
+      unless @store.alive?
+        fail 'Memcached does not appear to be running on localhost:11211. Use your favorite package manage to install and run it, or `docker-compose up -d`'
+      end
     end
 
     describe 'storage' do


### PR DESCRIPTION

I was trying to run the test suite locally, and it failed here because I didn't have memcached running (yet):

```
  1) Rack::MiniProfiler::MemcacheStore page struct storage can store a PageStruct and retrieve it
     Failure/Error: @client.set("#{@prefix}#{page_struct[:id]}", Marshal::dump(page_struct), @expires_in_seconds)

     Dalli::RingError:
       No server available
     # ./lib/mini_profiler/storage/memcache_store.rb:22:in `save'
     # ./spec/lib/storage/memcache_store_spec.rb:17:in `block (4 levels) in <top (required)>'
```

This adds a `alive?` method that the spec can check, and give more specific information to the user. I've also included a docker-compose.yml to give a one-liner to start memcached.