### PR TITLE
Enable advanced debugging for the sample app

### DIFF
--- a/website/sample.rb
+++ b/website/sample.rb
@@ -94,6 +94,7 @@ class SampleStorage < Rack::MiniProfiler::AbstractStore
   end
 end
 
+Rack::MiniProfiler.config.enable_advanced_debugging_tools = true
 Rack::MiniProfiler.config.storage = SampleStorage
 Rack::MiniProfiler.config.snapshot_hidden_custom_fields += ["application Version"]
 Rack::MiniProfiler.config.storage_failure = ->(e) do


### PR DESCRIPTION
I turned this on in https://github.com/MiniProfiler/rack-mini-profiler/pull/593 to help test, but think it makes sense to have in general.