### PR TITLE
Quick fix for "undefined local variable or method `query_string

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 group :test do
   gem 'codecov', require: false
   gem 'stackprof', require: false
+  gem 'memory_profiler', require: false
 end
 
 group :development do

--- a/lib/mini_profiler/actions.rb
+++ b/lib/mini_profiler/actions.rb
@@ -133,7 +133,7 @@ module Rack
           )
         end
 
-        query_params = Rack::Utils.parse_nested_query(query_string)
+        query_params = Rack::Utils.parse_nested_query(env['QUERY_STRING'])
         options = {
           ignore_files: query_params['memory_profiler_ignore_files'],
           allow_files: query_params['memory_profiler_allow_files'],

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -141,6 +141,34 @@ describe Rack::MiniProfiler do
     end
   end
 
+  it 'works with memory_profiler' do
+    pid = fork do # Avoid polluting main process with stackprof
+      require 'memory_profiler'
+
+      # Should store flamegraph for ?pp=profile-memory
+      Rack::MiniProfiler.config.enable_advanced_debugging_tools = true
+      get '/html?pp=profile-memory'
+      expect(last_response).to be_ok
+      expect(last_response.body).to match(/allocated memory by gem/)
+      expect(last_response.body).to match(/allocated memory by file/)
+      expect(last_response.body).to match(/allocated memory by location/)
+      expect(last_response.body).to match(/allocated memory by class/)
+      expect(last_response.body).to match(/allocated objects by gem/)
+      expect(last_response.body).to match(/allocated objects by file/)
+      expect(last_response.body).to match(/allocated objects by location/)
+      expect(last_response.body).to match(/allocated objects by class/)
+      expect(last_response.body).to match(/retained objects by gem/)
+      expect(last_response.body).to match(/retained objects by file/)
+      expect(last_response.body).to match(/retained objects by location/)
+      expect(last_response.body).to match(/retained objects by class/)
+      expect(last_response.body).to match(/Allocated String Report/)
+      expect(last_response.body).to match(/Retained String Report/)
+    end
+
+    Process.wait(pid)
+    expect($?.exitstatus).to eq(0)
+  end
+
   it 'works with async-flamegraph' do
     pid = fork do # Avoid polluting main process with stackprof
       require 'stackprof'


### PR DESCRIPTION
Today's update missed one 'query_string' variable.