### PR TITLE
Add option to ignore garbage collection frames with flamegraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ start_hidden                        | `false`                                   
 backtrace_threshold_ms              | `0`                                                     | Minimum SQL query elapsed time before a backtrace is recorded.
 flamegraph_sample_rate              | `0.5`                                                   | How often to capture stack traces for flamegraphs in milliseconds.
 flamegraph_mode                     | `:wall`                                                 | The [StackProf mode](https://github.com/tmm1/stackprof#all-options) to pass to `StackProf.run`.
+flamegraph_ignore_gc                | `false`                                                 | Whether to ignore garbage collection frames in flamegraphs.
 base_url_path                       | `'/mini-profiler-resources/'`                           | Path for assets; added as a prefix when naming assets and sought when responding to requests.
 cookie_path                         | `'/'`                                                   | Set-Cookie header path for profile cookie
 collapse_results                    | `true`                                                  | If multiple timing results exist in a single page, collapse them till clicked.

--- a/lib/mini_profiler.rb
+++ b/lib/mini_profiler.rb
@@ -302,12 +302,20 @@ module Rack
               mode = config.flamegraph_mode
             end
 
+            ignore_gc_match_data = action_parameters(env)['flamegraph_ignore_gc']
+
+            if ignore_gc_match_data
+              ignore_gc = ignore_gc_match_data == 'true'
+            else
+              ignore_gc = config.flamegraph_ignore_gc
+            end
+
             flamegraph = StackProf.run(
               mode: mode,
               raw: true,
               aggregate: false,
               interval: (sample_rate * 1000).to_i,
-              ignore_gc: config.flamegraph_ignore_gc
+              ignore_gc: ignore_gc
             ) do
               status, headers, body = @app.call(env)
             end

--- a/lib/mini_profiler.rb
+++ b/lib/mini_profiler.rb
@@ -306,7 +306,8 @@ module Rack
               mode: mode,
               raw: true,
               aggregate: false,
-              interval: (sample_rate * 1000).to_i
+              interval: (sample_rate * 1000).to_i,
+              ignore_gc: config.flamegraph_ignore_gc
             ) do
               status, headers, body = @app.call(env)
             end

--- a/lib/mini_profiler/config.rb
+++ b/lib/mini_profiler/config.rb
@@ -30,6 +30,7 @@ module Rack
           @backtrace_threshold_ms = 0
           @flamegraph_sample_rate = 0.5
           @flamegraph_mode = :wall
+          @flamegraph_ignore_gc = false
           @storage_failure = Proc.new do |exception|
             if @logger
               @logger.warn("MiniProfiler storage failure: #{exception.message}")
@@ -76,7 +77,7 @@ module Rack
         :storage_options, :user_provider, :enable_advanced_debugging_tools,
         :skip_sql_param_names, :suppress_encoding, :max_sql_param_length,
         :content_security_policy_nonce, :enable_hotwire_turbo_drive_support,
-        :flamegraph_mode, :profile_parameter
+        :flamegraph_mode, :flamegraph_ignore_gc, :profile_parameter
 
       # ui accessors
       attr_accessor :collapse_results, :max_traces_to_show, :position,

--- a/lib/mini_profiler/views.rb
+++ b/lib/mini_profiler/views.rb
@@ -161,6 +161,7 @@ module Rack
                 #{make_link "async-flamegraph", env} : store flamegraph data for this page and all its AJAX requests. Flamegraph links will be available in the mini-profiler UI (requires the stackprof gem).
                 #{make_link "flamegraph&flamegraph_sample_rate=1", env}: creates a flamegraph with the specified sample rate (in ms). Overrides value set in config
                 #{make_link "flamegraph&flamegraph_mode=cpu", env}: creates a flamegraph with the specified mode (one of cpu, wall, object, or custom). Overrides value set in config
+                #{make_link "flamegraph&flamegraph_ignore_gc=true", env}: ignore garbage collection frames in flamegraphs. Overrides value set in config
                 #{make_link "flamegraph_embed", env} : a graph representing sampled activity (requires the stackprof gem), embedded resources for use on an intranet.
                 #{make_link "trace-exceptions", env} : will return all the spots where your application raises exceptions
                 #{make_link "analyze-memory", env} : will perform basic memory analysis of heap

--- a/spec/integration/middleware_spec.rb
+++ b/spec/integration/middleware_spec.rb
@@ -56,6 +56,7 @@ describe Rack::MiniProfiler do
       expect(last_response.body).to include("async-flamegraph")
       expect(last_response.body).to include("flamegraph&flamegraph_sample_rate=1")
       expect(last_response.body).to include("flamegraph&flamegraph_mode=cpu")
+      expect(last_response.body).to include("flamegraph&flamegraph_ignore_gc=true")
       expect(last_response.body).to include("flamegraph_embed")
       expect(last_response.body).to include("trace-exceptions")
       expect(last_response.body).to include("analyze-memory")


### PR DESCRIPTION
Fixes https://github.com/MiniProfiler/rack-mini-profiler/issues/514

This adds a configuration option to ignore garbage collection via the [`ignore_gc`](https://github.com/tmm1/stackprof#all-options) option in StackProf. Users can override this configuration on a per-request basis via the `flamegraph_ignore_gc` query param.

I tested this change out on a separate app using this branch and confirmed garbage collection frames were visible by default, and hidden after setting `Rack::MiniProfiler.config.flamegraph_ignore_gc = true` or using the query param.