### PR TITLE
Fix Rack::File is deprecated and will be removed in Rack 3.1

### DIFF
--- a/lib/mini_profiler/actions.rb
+++ b/lib/mini_profiler/actions.rb
@@ -55,7 +55,12 @@ module Rack
         resources_env = env.dup
         resources_env['PATH_INFO'] = file_name
 
-        rack_file = Rack::File.new(resources_root, 'Cache-Control' => "max-age=#{cache_control_value}")
+        if Gem::Version.new(Rack.release) >= Gem::Version.new("2.1.0")
+          rack_file = Rack::Files.new(resources_root, 'Cache-Control' => "max-age=#{cache_control_value}")
+        else
+          rack_file = Rack::File.new(resources_root, 'Cache-Control' => "max-age=#{cache_control_value}")
+        end
+
         rack_file.call(resources_env)
       end
 


### PR DESCRIPTION
It fixed #600 with approache of No.2
> I guess there are two approaches to how to resolve this:
> 2. Keep the minimum compatible Rack version at >= 1.2.0 and write a compatibility check/layer in this gem instead.

It added to use `Rack::Files` for rack v2.1.0+.
if rack version is less v2.1.0, it remains to use `Rack::File`.

