### PR TITLE
Fixed the storage error when html is frozen

### DIFF
--- a/lib/mini_profiler.rb
+++ b/lib/mini_profiler.rb
@@ -469,7 +469,7 @@ module Rack
           safe_script = script.html_safe
         end
 
-        fragment.insert(index, safe_script)
+        (+fragment).insert(index, safe_script)
       else
         fragment
       end


### PR DESCRIPTION
I was getting this error in my logs when I was trying to load `/rack-mini-profiler/requests`.

>MiniProfiler storage failure: can't modify frozen String: "<!DOCTYPE html>\n<html>\n  <head>\n    <title>Rack::MiniProfiler Requests</title>\n  </head>\n  <body>\n  </body>\n</html>\n"

This PR fixes the issue by using string `+` method. It will use the original string if it is not frozen and create a duplicated string if it is frozen.