### PR TITLE
FEATURE: Support dynamic `config.content_security_policy_nonce`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+- [FEATURE] Support dynamic `config.content_security_policy_nonce` [#609](https://github.com/MiniProfiler/rack-mini-profiler/pull/609)
+
+
 ## 3.3.0 - 2023-12-07
 - [FEATURE] Use `?pp=flamegraph?ignore_gc=true` or `config.flamegraph_ignore_gc` to ignore gc in flamegraphs. [#599](https://github.com/MiniProfiler/rack-mini-profiler/pull/599)
 

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ snapshots_transport_destination_url | `nil`                                     
 snapshots_transport_auth_key        | `nil`                                                   | `POST` requests made by the snapshots transporter to the destination URL will have a `Mini-Profiler-Transport-Auth` header with the value of this config. Make sure you use a secure and random key for this config.
 snapshots_redact_sql_queries        | `true`                                                  | When this is true, SQL queries will be redacted from sampling snapshots, but the backtrace and duration of each SQL query will be saved with the snapshot to keep debugging performance issues possible.
 snapshots_transport_gzip_requests   | `false`                                                 | Make the snapshots transporter gzip the requests it makes to `snapshots_transport_destination_url`.
-content_security_policy_nonce       | Rails: Current nonce<br>Rack: nil                       | Set the content security policy nonce to use when inserting MiniProfiler's script block.
+content_security_policy_nonce       | Rails: Current nonce<br>Rack: nil                       | Set the content security policy nonce to use when inserting MiniProfiler's script block. Can be set to a static string, or a Proc which receives `env` and `response_headers` as arguments and returns the nonce.
 enable_hotwire_turbo_drive_support  | `false`                                                 | Enable support for Hotwire TurboDrive page transitions.
 profile_parameter                   | `'pp'`                                                  | The query parameter used to interact with this gem.
 

--- a/lib/mini_profiler.rb
+++ b/lib/mini_profiler.rb
@@ -440,7 +440,7 @@ module Rack
 
       if current.inject_js && content_type =~ /text\/html/
         response = Rack::Response.new([], status, headers)
-        script   = self.get_profile_script(env)
+        script   = self.get_profile_script(env, headers)
 
         if String === body
           response.write inject(body, script)

--- a/lib/mini_profiler/views.rb
+++ b/lib/mini_profiler/views.rb
@@ -28,7 +28,7 @@ module Rack
       # Use it when:
       # * you have disabled auto append behaviour throught :auto_inject => false flag
       # * you do not want script to be automatically appended for the current page. You can also call cancel_auto_inject
-      def get_profile_script(env)
+      def get_profile_script(env, response_headers = {})
         path = public_base_path(env)
         version = MiniProfiler::ASSET_VERSION
         if @config.assets_url
@@ -39,7 +39,12 @@ module Rack
         url = "#{path}includes.js?v=#{version}" if !url
         css_url = "#{path}includes.css?v=#{version}" if !css_url
 
-        content_security_policy_nonce = @config.content_security_policy_nonce ||
+        configured_nonce = @config.content_security_policy_nonce
+        if configured_nonce && !configured_nonce.is_a?(String)
+          configured_nonce = configured_nonce.call(env, response_headers)
+        end
+
+        content_security_policy_nonce = configured_nonce ||
                                         env["action_dispatch.content_security_policy_nonce"] ||
                                         env["secure_headers_content_security_policy_nonce"]
 


### PR DESCRIPTION
CSP nonce values change on every request, so accepting a static string as an option doesn't really make sense. This commit allows `config.content_security_policy_nonce` to be set to a Proc which is run for each request, and can return a nonce based on the `env` and current response headers.