### PR TITLE
respect flamegraph_mode in query string

### DIFF
--- a/lib/mini_profiler.rb
+++ b/lib/mini_profiler.rb
@@ -296,8 +296,8 @@ module Rack
 
             mode_match_data = action_parameters(env)['flamegraph_mode']
 
-            if mode_match_data && [:cpu, :wall, :object, :custom].include?(mode_match_data[1].to_sym)
-              mode = mode_match_data[1].to_sym
+            if mode_match_data && [:cpu, :wall, :object, :custom].include?(mode_match_data.to_sym)
+              mode = mode_match_data.to_sym
             else
               mode = config.flamegraph_mode
             end

--- a/spec/lib/profiler_spec.rb
+++ b/spec/lib/profiler_spec.rb
@@ -228,5 +228,13 @@ describe Rack::MiniProfiler do
     ensure
       Rack::MiniProfiler.config.enable_advanced_debugging_tools = original_enable_advanced_debugging_tools
     end
+
+    it 'passes flamegraph_mode parameter to StackProf.run' do
+      stackprof = double
+      stub_const('StackProf', stackprof)
+      expect(stackprof).to receive(:respond_to?).with(:run).and_return(true)
+      expect(stackprof).to receive(:run).with(hash_including(mode: :cpu)).and_return({})
+      profiler.call({ "PATH_INFO" => "/", "QUERY_STRING" => "pp=flamegraph&flamegraph_mode=cpu" })
+    end
   end
 end


### PR DESCRIPTION
Currently, parameters like `?flamegraph_mode=cpu` are not correctly passed to StackProf. Instead, `config.flamegraph_mode` will always be used.

This PR fixes the parameter check and extraction.