### PR TITLE
Reset total SQL count on route transition

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -1179,6 +1179,7 @@ var _MiniProfiler = (function() {
 
       reqs = 0;
       totalTime = 0;
+      totalSqlCount = 0;
       expandedResults = false;
       toArray(
         document.querySelectorAll(".profiler-results .profiler-result")


### PR DESCRIPTION
Fix the total SQL count not resetting on route transitions in SPAs when `show_total_sql_count` is enabled.