### PR TITLE
Requests page fails due to trying to modify a frozen string.

### DIFF
--- a/lib/mini_profiler.rb
+++ b/lib/mini_profiler.rb
@@ -329,7 +329,7 @@ module Rack
             )
           end
         elsif path == '/rack-mini-profiler/requests'
-          status, headers, body = [200, { 'Content-Type' => 'text/html' }, [blank_page_html]]
+          status, headers, body = [200, { 'Content-Type' => 'text/html' }, [blank_page_html.dup]] # important to dup here!
         else
           status, headers, body = @app.call(env)
         end
@@ -470,7 +470,7 @@ module Rack
           safe_script = script.html_safe
         end
 
-        fragment.dup.insert(index, safe_script)
+        fragment.insert(index, safe_script)
       else
         fragment
       end

--- a/lib/mini_profiler.rb
+++ b/lib/mini_profiler.rb
@@ -470,7 +470,7 @@ module Rack
           safe_script = script.html_safe
         end
 
-        fragment.insert(index, safe_script)
+        fragment.dup.insert(index, safe_script)
       else
         fragment
       end

--- a/spec/integration/middleware_spec.rb
+++ b/spec/integration/middleware_spec.rb
@@ -27,7 +27,7 @@ describe Rack::MiniProfiler do
       get '/rack-mini-profiler/requests', {}, 'HTTP_ACCEPT_ENCODING' => 'gzip, compress'
 
       expect(last_response.body).to include('<title>Rack::MiniProfiler Requests</title>')
-      expect(last_response.body).to match('<body>\n  </body>')
+      expect(last_response.body).to match('<body>\n  <script async nonce="" type="text/javascript" id="mini-profiler"')
     end
   end
 


### PR DESCRIPTION
Frozen strings cannot have `#insert` called on them, this was causing an error on the requests page. This PR fixes that issue.

Fixes #611 