### PR TITLE
Drop support for Ruby 2.7 and 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.3", "3.2", "3.1", "3.0", "2.7"]
+        ruby: ["3.4", "3.3", "3.2", "3.1"]
         redis: ["5.x"]
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- [BREAKING CHANGE] Ruby version 3.1.0 or later is required.
+
 ## 3.3.1 - 2024-02-15
 - [FEATURE] Support dynamic `config.content_security_policy_nonce` [#609](https://github.com/MiniProfiler/rack-mini-profiler/pull/609)
 - [FEATURE] Add flamgraph path to response header: [#601](https://github.com/MiniProfiler/rack-mini-profiler/pull/601)

--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     "CHANGELOG.md"
   ]
   s.add_runtime_dependency 'rack', '>= 1.2.0'
-  s.required_ruby_version = '>= 2.7.0'
+  s.required_ruby_version = '>= 3.1.0'
 
   s.metadata = {
     'source_code_uri' => Rack::MiniProfiler::SOURCE_CODE_URI,


### PR DESCRIPTION
These versions are already EOL. Adds Ruby 3.4 to CI matrix.