### PR TITLE
respect flamegraph_mode in query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - [BREAKING CHANGE] Ruby version 3.1.0 or later is required. [#632](https://github.com/MiniProfiler/rack-mini-profiler/pull/632)
-- [FIX] Truncate long profiler name in profiler popup. [#634](https://github.com/MiniProfiler/rack-mini-profiler/pull/634) 
+- [FIX] Truncate long profiler name in profiler popup. [#634](https://github.com/MiniProfiler/rack-mini-profiler/pull/634)
+- [FIX] `flamegraph_mode` query param having no effect. [#634](https://github.com/MiniProfiler/rack-mini-profiler/pull/623)
 
 ## 3.3.1 - 2024-02-15
 - [FEATURE] Support dynamic `config.content_security_policy_nonce` [#609](https://github.com/MiniProfiler/rack-mini-profiler/pull/609)

--- a/lib/mini_profiler.rb
+++ b/lib/mini_profiler.rb
@@ -296,8 +296,8 @@ module Rack
 
             mode_match_data = action_parameters(env)['flamegraph_mode']
 
-            if mode_match_data && [:cpu, :wall, :object, :custom].include?(mode_match_data[1].to_sym)
-              mode = mode_match_data[1].to_sym
+            if mode_match_data && [:cpu, :wall, :object, :custom].include?(mode_match_data.to_sym)
+              mode = mode_match_data.to_sym
             else
               mode = config.flamegraph_mode
             end

--- a/spec/lib/profiler_spec.rb
+++ b/spec/lib/profiler_spec.rb
@@ -230,5 +230,13 @@ describe Rack::MiniProfiler do
     ensure
       Rack::MiniProfiler.config.enable_advanced_debugging_tools = original_enable_advanced_debugging_tools
     end
+
+    it 'passes flamegraph_mode parameter to StackProf.run' do
+      stackprof = double
+      stub_const('StackProf', stackprof)
+      expect(stackprof).to receive(:respond_to?).with(:run).and_return(true)
+      expect(stackprof).to receive(:run).with(hash_including(mode: :cpu)).and_return({})
+      profiler.call({ "PATH_INFO" => "/", "QUERY_STRING" => "pp=flamegraph&flamegraph_mode=cpu" })
+    end
   end
 end


### PR DESCRIPTION
Currently, parameters like `?flamegraph_mode=cpu` are not correctly passed to StackProf. Instead, `config.flamegraph_mode` will always be used.

This PR fixes the parameter check and extraction.