### PR TITLE
Fix rubocop and rspec rake tasks

### DIFF
--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rubocop-discourse'
   s.add_development_dependency 'listen'
   s.add_development_dependency 'webpacker'
-  s.add_development_dependency 'rails', '~> 6.0'
+  s.add_development_dependency 'rails', '~> 7.0'
   s.add_development_dependency 'webmock', '3.9.1'
   s.add_development_dependency 'rubyzip'
 


### PR DESCRIPTION
These commands were generating an uninitialized constant error (ActiveSupport::LoggerThreadSafeLevel::Logger) in Rails. A fix was merged to Rails 7+ but not 6 which was getting required when running bundle.