### PR TITLE
Fix linting

### DIFF
--- a/lib/mini_profiler.rb
+++ b/lib/mini_profiler.rb
@@ -417,7 +417,7 @@ module Rack
     end
 
     def action_parameters(env)
-      query_params = Rack::Utils.parse_nested_query(env['QUERY_STRING'])
+      Rack::Utils.parse_nested_query(env['QUERY_STRING'])
     end
 
     def inject_profiler(env, status, headers, body)

--- a/lib/mini_profiler/actions.rb
+++ b/lib/mini_profiler/actions.rb
@@ -130,7 +130,7 @@ module Rack
 
         unless defined?(MemoryProfiler) && MemoryProfiler.respond_to?(:report)
           message = "Please install the memory_profiler gem and require it: add gem 'memory_profiler' to your Gemfile"
-          status, headers, body = @app.call(env)
+          _status, headers, body = @app.call(env)
           body.close if body.respond_to? :close
 
           return client_settings.handle_cookie(


### PR DESCRIPTION
Fix for the lint warnings that occur when running the test suite:

```
$ bundle exec rspec
../rack-mini-profiler/lib/mini_profiler.rb:420: warning: assigned but unused variable - query_params
../rack-mini-profiler/lib/mini_profiler/actions.rb:133: warning: assigned but unused variable - status
Run options: include {:focus=>true}

All examples were filtered out; ignoring {:focus=>true}
................................................................................................................................................................................................
....................................................................................................

Finished in 7.32 seconds (files took 1.56 seconds to load)
292 examples, 0 failures

Coverage report generated for RSpec to ../rack-mini-profiler/coverage.
Line Coverage: 89.71% (1595 / 1778)
```
