### PR TITLE
Emphasize note about storage in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ rack-mini-profiler is designed with production profiling in mind. To enable that
   end
 ```
 
+> [!WARNING]
 > If your production application is running on more than one server (or more than one dyno) you will need to configure rack mini profiler's storage to use Redis or Memcache. See [storage](#storage) for information on changing the storage backend.
 
 Note:


### PR DESCRIPTION
I glanced over this paragraph when I was reading the docs, because the blockquote de-emphasized it visually. Use new GitHub highlights to make it stand out.

Before:
<img width="770" alt="Screenshot 2025-03-11 at 13 59 26" src="https://github.com/user-attachments/assets/f52ae9a9-3a5d-4672-b891-02a096528c27" />

After:
<img width="775" alt="Screenshot 2025-03-11 at 13 58 48" src="https://github.com/user-attachments/assets/629e27a5-69cf-43e9-9796-b55642adbfbe" />
