### PR TITLE
Disable advanced_debugging_tools by default in development

### DIFF
--- a/lib/mini_profiler_rails/railtie.rb
+++ b/lib/mini_profiler_rails/railtie.rb
@@ -59,7 +59,6 @@ module Rack::MiniProfilerRails
 
     # Install the Middleware
     app.middleware.insert(0, Rack::MiniProfiler)
-    c.enable_advanced_debugging_tools = Rails.env.development?
 
     if ::Rack::MiniProfiler.patch_rails?
       # Attach to various Rails methods


### PR DESCRIPTION
The `enable_advanced_debugging_tools` setting is potentially dangerous, especially in development environments that are exposed to external networks. For example, if you run a Rails server bound to a public interface (e.g. `-b 0.0.0.0`), anyone on the local network can access sensitive information such as environment variables or memory debugging data. This risk is even greater if the application is exposed via a tunnel for webhook testing or similar purposes.

Although the README states that `enable_advanced_debugging_tools` is disabled by default, the current Railtie enables it in development mode. This change corrects that inconsistency and prioritizes safety by requiring explicit opt-in for these tools.