### PR TITLE
feat: add ESC key to collapse expanded profiler results

### DIFF
--- a/lib/html/includes.js
+++ b/lib/html/includes.js
@@ -214,6 +214,25 @@ var _MiniProfiler = (function() {
     return tempElement.children[0];
   };
 
+  var collapseResults = function collapseResults() {
+    if (expandedResults && totalsControl && container) {
+      // Hide all individual results except totals
+      toArray(
+        container.querySelectorAll(".profiler-result")
+      ).forEach(function(el) {
+        if (el !== totalsControl) {
+          el.style.display = "none";
+        }
+      });
+
+      // Show totals control again
+      totalsControl.style.display = "block";
+
+      // Reset expanded state
+      expandedResults = false;
+    }
+  };
+
   var buttonShow = function buttonShow(json) {
     var result = renderTemplate(json);
     totalTime += parseFloat(json.duration_milliseconds, 10);
@@ -518,7 +537,13 @@ var _MiniProfiler = (function() {
       }
     );
 
+    var isEscPress = e.type == "keyup" && e.which == 27;
+
     if (!popup.length) {
+      // Handle ESC when no popups are open but results are expanded
+      if (isEscPress && expandedResults) {
+        collapseResults();
+      }
       return;
     }
 
@@ -528,7 +553,6 @@ var _MiniProfiler = (function() {
         ".profiler-queries"
       ),
       bg = document.querySelector(".profiler-queries-bg"),
-      isEscPress = e.type == "keyup" && e.which == 27,
       hidePopup = false,
       hideQueries = false;
 

--- a/lib/mini_profiler/asset_version.rb
+++ b/lib/mini_profiler/asset_version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Rack
   class MiniProfiler
-    ASSET_VERSION = 'e0bcc9ce0ae3bb5d6b736b6f282f601f'
+    ASSET_VERSION = '1592fcee961471b6d33bb772925ef913'
   end
 end


### PR DESCRIPTION
When profiler results are expanded, pressing ESC will collapse them back to the summary view. Integrates with existing ESC key handling for popups.