### PR TITLE
CI: use actions/checkout@v4 to avoid deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         ruby: ["3.4", "3.3", "3.2", "3.1"]
         redis: ["5.x"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
This avoids any deprecation warnings about old Actions.