### PR TITLE
CI: Configure setup-ruby to use a compatible RubyGems in order to build green on Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          rubygems: latest # `gem update --system` is run to update to the latest compatible RubyGems version.
       - name: Setup redis
         uses: shogo82148/actions-setup-redis@v1
         with:


### PR DESCRIPTION
This PR configures setup-ruby to use the latest-compatible RubyGems that for the current running Ruby.

This is an attempt to make mini_racer install correctly, on Ruby 3.1... which panned out, we are now building green 🟢 again.