### PR TITLE
Ensure compatibility with Rack 2.x and 3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,12 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }} (Rack ~> ${{ matrix.rack }})
     services:
+      redis:
+        image: "redis"
+        ports:
+          - 6379:6379
       memcached:
         image: memcached:1.6.9
         ports:
@@ -22,8 +26,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.4", "3.3", "3.2", "3.1"]
-        redis: ["5.x"]
+        ruby: ["3.4", "3.3", "3.2"]
+        rack: ["2.0", "3.0"]
+    env:
+      RACK_VERSION: ${{ matrix.rack }}
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -31,10 +37,6 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           rubygems: latest # `gem update --system` is run to update to the latest compatible RubyGems version.
-      - name: Setup redis
-        uses: shogo82148/actions-setup-redis@v1
-        with:
-          redis-version: ${{ matrix.redis }}
       - name: Tests
         run: bundle exec rspec
       - name: Rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ ruby '>= 2.7.0'
 
 gemspec
 
+if ENV["CI"]
+  gem "rack", "~> #{ENV['RACK_VERSION']}"
+end
+
 group :test do
   gem 'codecov', require: false
   gem 'stackprof', require: false

--- a/lib/mini_profiler/gc_profiler.rb
+++ b/lib/mini_profiler/gc_profiler.rb
@@ -151,7 +151,7 @@ String stats:
       body << "#{count} : #{string}\n"
     end
 
-    [200, { 'Content-Type' => 'text/plain' }, body]
+    [200, { Rack::CONTENT_TYPE => 'text/plain' }, body]
   ensure
     prev_gc_state ? GC.disable : GC.enable
   end

--- a/spec/integration/middleware_spec.rb
+++ b/spec/integration/middleware_spec.rb
@@ -20,7 +20,7 @@ describe Rack::MiniProfiler do
     def app
       Rack::Builder.new do
         use Rack::MiniProfiler
-        run lambda { |_env| [200, { 'Content-Type' => 'text/html' }, [+'<html><body><h1>Hi</h1></body></html>']] }
+        run lambda { |_env| [200, { Rack::CONTENT_TYPE => 'text/html' }, [+'<html><body><h1>Hi</h1></body></html>']] }
       end
     end
     it 'is an empty page' do
@@ -35,7 +35,7 @@ describe Rack::MiniProfiler do
     def app
       Rack::Builder.new do
         use Rack::MiniProfiler
-        run lambda { |_env| [200, { 'Content-Type' => 'text/html' }, [+'<html><body><h1>Hi</h1></body></html>']] }
+        run lambda { |_env| [200, { Rack::CONTENT_TYPE => 'text/html' }, [+'<html><body><h1>Hi</h1></body></html>']] }
       end
     end
     it 'shows commands' do
@@ -75,7 +75,7 @@ describe Rack::MiniProfiler do
     def app
       Rack::Builder.new do
         use Rack::MiniProfiler
-        run lambda { |_env| [200, { 'Content-Type' => 'text/html' }, [+'<html><body><h1>Hi</h1></body></html>']] }
+        run lambda { |_env| [200, { Rack::CONTENT_TYPE => 'text/html' }, [+'<html><body><h1>Hi</h1></body></html>']] }
       end
     end
     it 'advanced tools are disabled' do
@@ -94,7 +94,7 @@ describe Rack::MiniProfiler do
           lambda do |_env|
             [
               201,
-              { 'Content-Type' => 'text/html', 'X-CUSTOM' => "1" },
+              { Rack::CONTENT_TYPE => 'text/html', 'X-CUSTOM' => "1" },
               [+'<html><body><h1>Hi</h1></body></html>'],
             ]
           end
@@ -118,7 +118,7 @@ describe Rack::MiniProfiler do
         expect(last_response.body).to eq(
           'Please install the memory_profiler gem and require it: add gem \'memory_profiler\' to your Gemfile'
         )
-        expect(last_response.headers['Content-Type']).to eq('text/plain; charset=utf-8')
+        expect(last_response.headers[Rack::CONTENT_TYPE]).to eq('text/plain; charset=utf-8')
         expect(last_response.headers['X-CUSTOM']).to eq('1')
         expect(last_response.status).to eq(500)
       end
@@ -130,7 +130,7 @@ describe Rack::MiniProfiler do
         expect(last_response.body).to eq(
           'Please install the stackprof gem and require it: add gem \'stackprof\' to your Gemfile'
         )
-        expect(last_response.headers['Content-Type']).to eq('text/plain; charset=utf-8')
+        expect(last_response.headers[Rack::CONTENT_TYPE]).to eq('text/plain; charset=utf-8')
         expect(last_response.headers['X-CUSTOM']).to eq('1')
         expect(last_response.status).to eq(201)
       end
@@ -142,7 +142,7 @@ describe Rack::MiniProfiler do
         expect(last_response.body).to eq(
           'Please install the stackprof gem and require it: add gem \'stackprof\' to your Gemfile'
         )
-        expect(last_response.headers['Content-Type']).to eq('text/plain; charset=utf-8')
+        expect(last_response.headers[Rack::CONTENT_TYPE]).to eq('text/plain; charset=utf-8')
         expect(last_response.headers['X-CUSTOM']).to eq('1')
         expect(last_response.status).to eq(201)
       end
@@ -154,7 +154,7 @@ describe Rack::MiniProfiler do
       Rack::Builder.new do
         use Rack::MiniProfiler
         use Rack::Deflater
-        run lambda { |_env| [200, { 'Content-Type' => 'text/html' }, [+'<html><body><h1>Hi</h1></body></html>']] }
+        run lambda { |_env| [200, { Rack::CONTENT_TYPE => 'text/html' }, [+'<html><body><h1>Hi</h1></body></html>']] }
       end
     end
 
@@ -190,7 +190,7 @@ describe Rack::MiniProfiler do
       Rack::Builder.new do
         use Rack::Deflater
         use Rack::MiniProfiler
-        run lambda { |_env| [200, { 'Content-Type' => 'text/html' }, [+'<html><body><h1>Hi</h1></body></html>']] }
+        run lambda { |_env| [200, { Rack::CONTENT_TYPE => 'text/html' }, [+'<html><body><h1>Hi</h1></body></html>']] }
       end
     end
 
@@ -223,7 +223,7 @@ describe Rack::MiniProfiler do
     def app
       Rack::Builder.new do
         use Rack::MiniProfiler
-        run lambda { |_env| [200, { 'Content-Type' => 'text/html' }, [+'<html><body><h1>Hi</h1></body></html>']] }
+        run lambda { |_env| [200, { Rack::CONTENT_TYPE => 'text/html' }, [+'<html><body><h1>Hi</h1></body></html>']] }
       end
     end
 
@@ -249,7 +249,7 @@ describe Rack::MiniProfiler do
         use Rack::MiniProfiler
         run lambda { |env|
           env["action_dispatch.content_security_policy_nonce"] = "railsnonce"
-          [200, { 'Content-Type' => 'text/html' }, [+'<html><body><h1>Hello world</h1></body></html>']]
+          [200, { Rack::CONTENT_TYPE => 'text/html' }, [+'<html><body><h1>Hello world</h1></body></html>']]
         }
       end
     end
@@ -278,7 +278,7 @@ describe Rack::MiniProfiler do
 
       (env, response_headers) = proc_arguments
       expect(env["REQUEST_METHOD"]).to eq("GET")
-      expect(response_headers["Content-Type"]).to eq("text/html")
+      expect(response_headers[Rack::CONTENT_TYPE]).to eq("text/html")
     end
   end
 end

--- a/spec/integration/mini_profiler_spec.rb
+++ b/spec/integration/mini_profiler_spec.rb
@@ -10,88 +10,88 @@ describe Rack::MiniProfiler do
     @app ||= Rack::Builder.new {
       use Rack::MiniProfiler
       map '/path2/a' do
-        run lambda { |env| [200, { 'Content-Type' => 'text/html' }, +'<h1>path1</h1>'] }
+        run lambda { |env| [200, { Rack::CONTENT_TYPE => 'text/html' }, +'<h1>path1</h1>'] }
       end
       map '/path1/a' do
-        run lambda { |env| [200, { 'Content-Type' => 'text/html' }, +'<h1>path2</h1>'] }
+        run lambda { |env| [200, { Rack::CONTENT_TYPE => 'text/html' }, +'<h1>path2</h1>'] }
       end
       map '/cached-resource' do
         run lambda { |env|
           ims = env['HTTP_IF_MODIFIED_SINCE'] || ""
           if ims.size > 0
-            [304, { 'Content-Type' => 'application/json' }, '']
+            [304, { Rack::CONTENT_TYPE => 'application/json' }, '']
           else
-            [200, { 'Content-Type' => 'application/json', 'Cache-Control' => 'original-cache-control' }, '{"name": "Ryan"}']
+            [200, { Rack::CONTENT_TYPE => 'application/json', Rack::CACHE_CONTROL => 'original-cache-control' }, '{"name": "Ryan"}']
           end
         }
       end
       map '/post' do
-        run lambda { |env| [302, { 'Content-Type' => 'text/html' }, +'<h1>POST</h1>'] }
+        run lambda { |env| [302, { Rack::CONTENT_TYPE => 'text/html' }, +'<h1>POST</h1>'] }
       end
       map '/html' do
-        run lambda { |env| [200, { 'Content-Type' => 'text/html' }, +"<html><BODY><h1>Hi</h1></BODY>\n \t</html>"] }
+        run lambda { |env| [200, { Rack::CONTENT_TYPE => 'text/html' }, +"<html><BODY><h1>Hi</h1></BODY>\n \t</html>"] }
       end
       map '/explicitly-allowed-html' do
         run lambda { |env|
           Rack::MiniProfiler.authorize_request
-          [200, { 'Content-Type' => 'text/html' }, +"<html><BODY><h1>Hi</h1></BODY>\n \t</html>"]
+          [200, { Rack::CONTENT_TYPE => 'text/html' }, +"<html><BODY><h1>Hi</h1></BODY>\n \t</html>"]
         }
       end
       map '/implicitbody' do
-        run lambda { |env| [200, { 'Content-Type' => 'text/html' }, +"<html><h1>Hi</h1></html>"] }
+        run lambda { |env| [200, { Rack::CONTENT_TYPE => 'text/html' }, +"<html><h1>Hi</h1></html>"] }
       end
       map '/implicitbodyhtml' do
-        run lambda { |env| [200, { 'Content-Type' => 'text/html' }, +"<h1>Hi</h1>"] }
+        run lambda { |env| [200, { Rack::CONTENT_TYPE => 'text/html' }, +"<h1>Hi</h1>"] }
       end
       map '/db' do
         run lambda { |env|
           ::Rack::MiniProfiler.record_sql("I want to be, in a db", 10)
-          [200, { 'Content-Type' => 'text/html' }, +'<h1>Hi+db</h1>']
+          [200, { Rack::CONTENT_TYPE => 'text/html' }, +'<h1>Hi+db</h1>']
         }
       end
       map '/3ms' do
         run lambda { |env|
           sleep(0.003)
-          [200, { 'Content-Type' => 'text/html' }, +'<h1>Hi</h1>']
+          [200, { Rack::CONTENT_TYPE => 'text/html' }, +'<h1>Hi</h1>']
         }
       end
       map '/explicitly-allowed' do
         run lambda { |env|
           Rack::MiniProfiler.authorize_request
-          [200, { 'Content-Type' => 'text/html' }, +'<h1>path1</h1>']
+          [200, { Rack::CONTENT_TYPE => 'text/html' }, +'<h1>path1</h1>']
         }
       end
       map '/rails_engine' do
         run lambda { |env|
           env['SCRIPT_NAME'] = '/rails_engine'  # Rails engines do that
-          [200, { 'Content-Type' => 'text/html' }, +'<html><h1>Hi</h1></html>']
+          [200, { Rack::CONTENT_TYPE => 'text/html' }, +'<html><h1>Hi</h1></html>']
         }
       end
       map '/under_passenger' do
         run lambda { |env|
-          [200, { 'Content-Type' => 'text/html' }, +'<html><h1>and I ride and I ride</h1></html>']
+          [200, { Rack::CONTENT_TYPE => 'text/html' }, +'<html><h1>and I ride and I ride</h1></html>']
         }
       end
       map '/create' do
         run lambda { |env|
-          [201, { 'Content-Type' => 'text/html' }, +'<html><h1>success</h1></html>']
+          [201, { Rack::CONTENT_TYPE => 'text/html' }, +'<html><h1>success</h1></html>']
         }
       end
       map '/notallowed' do
         run lambda { |env|
-          [403, { 'Content-Type' => 'text/html' }, +'<html><h1>you are not allowed here</h1></html>']
+          [403, { Rack::CONTENT_TYPE => 'text/html' }, +'<html><h1>you are not allowed here</h1></html>']
         }
       end
       map '/whoopsie-daisy' do
         run lambda { |env|
-          [500, { 'Content-Type' => 'text/html' }, +'<html><h1>whoopsie daisy</h1></html>']
+          [500, { Rack::CONTENT_TYPE => 'text/html' }, +'<html><h1>whoopsie daisy</h1></html>']
         }
       end
       map '/test-snapshots-custom-fields' do
         run lambda { |env|
           qp = Rack::Utils.parse_nested_query(env['QUERY_STRING'])
           qp.each { |k, v| Rack::MiniProfiler.add_snapshot_custom_field(k, v) }
-          [200, { 'Content-Type' => 'text/html' }, +'<html><h1>custom fields</h1></html>']
+          [200, { Rack::CONTENT_TYPE => 'text/html' }, +'<html><h1>custom fields</h1></html>']
         }
       end
     }.to_app
@@ -450,12 +450,12 @@ describe Rack::MiniProfiler do
   describe 'gc profiler' do
     it "should return a report" do
       get '/html?pp=profile-gc'
-      expect(last_response['Content-Type']).to include('text/plain')
+      expect(last_response[Rack::CONTENT_TYPE]).to include('text/plain')
     end
 
     it "should return a report when an HTTP header is used" do
       get '/html', nil, { 'HTTP_X_RACK_MINI_PROFILER' => 'profile-gc' }
-      expect(last_response['Content-Type']).to include('text/plain')
+      expect(last_response[Rack::CONTENT_TYPE]).to include('text/plain')
     end
   end
 

--- a/spec/integration/trace_exceptions_spec.rb
+++ b/spec/integration/trace_exceptions_spec.rb
@@ -14,7 +14,7 @@ describe 'Rack::MiniProfiler - trace_exceptions' do
     @app ||= Rack::Builder.new {
       use Rack::MiniProfiler
       map '/no_exceptions' do
-        run lambda { |_env| [200, { 'Content-Type' => 'text/html' }, '<h1>Success</h1>'] }
+        run lambda { |_env| [200, { Rack::CONTENT_TYPE => 'text/html' }, '<h1>Success</h1>'] }
       end
       map '/raise_exceptions' do
         # This route raises 3 exceptions, catches them, and returns a successful response
@@ -34,7 +34,7 @@ describe 'Rack::MiniProfiler - trace_exceptions' do
           rescue
             # Ignore the exception
           end
-          [200, { 'Content-Type' => 'text/html' }, '<h1>Exception raised but success returned</h1>']
+          [200, { Rack::CONTENT_TYPE => 'text/html' }, '<h1>Exception raised but success returned</h1>']
         }
       end
     }.to_app

--- a/spec/lib/client_settings_spec.rb
+++ b/spec/lib/client_settings_spec.rb
@@ -44,7 +44,7 @@ describe Rack::MiniProfiler::ClientSettings do
       @settings.disable_profiling = false
       hash = {}
       @settings.write!(hash)
-      expect(hash["set-cookie"]).to include("path=/;")
+      expect(hash[Rack::SET_COOKIE]).to include("path=/;")
     end
 
     it 'should correctly set cookie with correct path' do
@@ -52,7 +52,7 @@ describe Rack::MiniProfiler::ClientSettings do
       @settings.disable_profiling = false
       hash = {}
       @settings.write!(hash)
-      expect(hash["set-cookie"]).to include("path=/test;")
+      expect(hash[Rack::SET_COOKIE]).to include("path=/test;")
     end
 
     it 'writes auth token for authorized reqs' do
@@ -60,7 +60,7 @@ describe Rack::MiniProfiler::ClientSettings do
       Rack::MiniProfiler.authorize_request
       hash = {}
       @settings.write!(hash)
-      expect(hash["set-cookie"]).to include(@store.allowed_tokens.join("|"))
+      expect(hash[Rack::SET_COOKIE]).to include(@store.allowed_tokens.join("|"))
     end
 
     it 'does nothing on short unauthed requests' do
@@ -80,7 +80,7 @@ describe Rack::MiniProfiler::ClientSettings do
         @settings.handle_cookie([200, hash, []])
       end
 
-      expect(hash["set-cookie"]).to include("max-age=0")
+      expect(hash[Rack::SET_COOKIE]).to include("max-age=0")
     end
   end
 

--- a/spec/lib/profiler_spec.rb
+++ b/spec/lib/profiler_spec.rb
@@ -208,9 +208,9 @@ describe Rack::MiniProfiler do
     it "returns error response when stackprof isn't installed" do
       response = profiler.call({ "PATH_INFO" => "/", "QUERY_STRING" => "pp=flamegraph" })
 
-      expect(response).to eq([
+      expect(response).to match([
         200,
-        { "Content-Type" => "text/plain; charset=utf-8", "set-cookie" => "__profilin=p%3Dt; path=/; httponly; samesite=lax" },
+        { Rack::CONTENT_TYPE => "text/plain; charset=utf-8", Rack::SET_COOKIE => %r{^__profilin=p%3Dt; path=/; httponly; samesite=lax$}i },
         ["Please install the stackprof gem and require it: add gem 'stackprof' to your Gemfile"],
       ])
     end
@@ -221,9 +221,9 @@ describe Rack::MiniProfiler do
 
       response = profiler.call({ "PATH_INFO" => "/", "QUERY_STRING" => "pp=profile-memory" })
 
-      expect(response).to eq([
+      expect(response).to match([
         500,
-        { "Content-Type" => "text/plain; charset=utf-8", "set-cookie" => "__profilin=p%3Dt; path=/; httponly; samesite=lax" },
+        { Rack::CONTENT_TYPE => "text/plain; charset=utf-8", Rack::SET_COOKIE => %r{^__profilin=p%3Dt; path=/; httponly; samesite=lax$}i },
         ["Please install the memory_profiler gem and require it: add gem 'memory_profiler' to your Gemfile"],
       ])
 


### PR DESCRIPTION
Some parts of the code are changing the headers from the Rack request, but are using capitalized headers when doing so. If the underlying object is not a bare hash but either a `Rack::Utils::HeaderHash` or a `Rack::Headers` object, then everything will work as expected. But sometimes the headers object can be a bare hash (that can be the case when Rails is serving static files) and if Rack 3 is in use, things can break.

This PR ensures the headers names are compliant with both versions of Rack. (mainly by using things like `Rack::CONTENT_TYPE` instead of writing directly `Content-Type`/`content-type`)