### PR TITLE
Fix the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.4", "3.3", "3.2"]
-        rack: ["2.2", "3.1", "3.2"]
+        rack: ["2.2.0", "3.1.0", "3.2.0"]
     env:
       RACK_VERSION: ${{ matrix.rack }}
     steps:


### PR DESCRIPTION
The Gemfile is using the "~>" operator to install Rack, that way we always get the latest available version for a given version.

The current versions in the CI matrix are using only major and minor version (like 3.2), meaning bundler will install the latest available minor version (meaning if a version 3.3 is released it will be installed instead of the 3.2 series). To fix that, it’s just a matter of providing a patch level. So providing 3.2.0 will only install 3.2 versions, as wanted.