### PR TITLE
Drop support for Ruby 3.1 as it is EOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- [BREAKING CHANGE] Ruby version 3.2.0 or later is required. [#632](https://github.com/MiniProfiler/rack-mini-profiler/pull/658)
+
 ## 4.0.1 - 2025-07-31
 
 - [FIX] Ensure Rack 2 / 3 cross compatibility [#653](https://github.com/MiniProfiler/rack-mini-profiler/pull/653)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you feel like taking on any of this start an issue and update us on your prog
 
 ## Installation
 
-Install/add to Gemfile in Ruby 3.1+
+Install/add to Gemfile in Ruby 3.2+
 
 ```ruby
 gem 'rack-mini-profiler'

--- a/rack-mini-profiler.gemspec
+++ b/rack-mini-profiler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     "CHANGELOG.md"
   ]
   s.add_runtime_dependency 'rack', '>= 1.2.0'
-  s.required_ruby_version = '>= 3.1.0'
+  s.required_ruby_version = '>= 3.2.0'
 
   s.metadata = {
     'source_code_uri' => Rack::MiniProfiler::SOURCE_CODE_URI,


### PR DESCRIPTION
Ruby 3.1 is EOL as of ~earlier this year~ last year ([source](https://www.ruby-lang.org/en/downloads/branches/)) and as such we should probably drop support like https://github.com/MiniProfiler/rack-mini-profiler/pull/632 did for Ruby 3.0. Additionally this repo/gem's CI doesn't even test Ruby 3.1 anymore as of https://github.com/MiniProfiler/rack-mini-profiler/pull/653 from July 31st of this year. Thus, it's in fact a bit risky to still allow Ruby 3.1.

Inspired by https://github.com/MiniProfiler/rack-mini-profiler/pull/631